### PR TITLE
Add the OLM config

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -1,0 +1,57 @@
+# This configuration is a placeholder. Replace any values with relevant values for your
+# service controller project.
+---
+annotations:
+  capabilityLevel: Basic Install
+  shortDescription: AWS API Gateway v2 controller is a service controller for managing API Gateway v2 resources
+    in Kubernetes
+displayName: AWS Controllers for Kubernetes - Amazon API Gateway v2
+description: |-
+  Manage Amazon API Gateway v2 resources in AWS from within your Kubernetes cluster.
+  
+
+  **About Amazon API Gateway v2**
+
+
+  Amazon API Gateway is a fully managed service that makes it easy for developers to create, publish, maintain, monitor, and secure APIs at any scale. APIs act as the "front door" for applications to access data, business logic, or functionality from your backend services. Using API Gateway, you can create RESTful APIs and WebSocket APIs that enable real-time two-way communication applications. API Gateway supports containerized and serverless workloads, as well as web applications.
+
+
+  API Gateway handles all the tasks involved in accepting and processing up to hundreds of thousands of concurrent API calls, including traffic management, CORS support, authorization and access control, throttling, monitoring, and API version management. API Gateway has no minimum fees or startup costs. You pay for the API calls you receive and the amount of data transferred out and, with the API Gateway tiered pricing model, you can reduce your cost as your API usage scales.
+
+  
+  **About the AWS Controllers for Kubernetes**
+
+  
+  This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
+  project. This project is currently in **developer preview**. 
+samples:
+- kind: APIMapping
+  spec: '{}'
+- kind: API
+  spec: '{}'
+- kind: Authorizer
+  spec: '{}'
+- kind: Deployment
+  spec: '{}'
+- kind: DomainName
+  spec: '{}'
+- kind: IntegrationResponse
+  spec: '{}'
+- kind: Integration
+  spec: '{}'
+- kind: Model
+  spec: '{}'
+- kind: RouteResponse
+  spec: '{}'
+- kind: Route
+  spec: '{}'
+- kind: Stage
+  spec: '{}'
+- kind: VPCLink
+  spec: '{}'
+maintainers:
+- name: "Your Team Name"
+  email: "your-team@example.com"
+links:
+- name: Amazon API Gateway v2 Developer Resources
+  url: "https://aws.amazon.com/api-gateway/resources/"


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

# Related Issue
https://github.com/aws-controllers-k8s/community/issues/744

# Change Description
This PR will add the configuration necessary for the `ack-generate olm` subcommand to render the appropriate Operator Lifecycle Manager ("OLM") bundle assets into the repository.

For reference, the PR merging the `olm` subcommand is here: https://github.com/aws-controllers-k8s/code-generator/commit/cb1d017ccc59feaa7ed247df502a2414f37344b2

This configuration informs `ack-generate` on exactly how to lay down a [ClusterServiceVersion](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md) "kustomize" base, which is then used by Operator SDK to generate a bundle to represent a particular version of the project in OLM

Things to note:

* I just grabbed service information and links from product pages, but those can be changed.
* The maintainer contact information is left with a placeholder and will need to be updated by controller maintainers to an appropriate value before this is put to use.
* The CRDs listed in the samples section were aligned to those found in `config/crd/bases`. As this changes, so do the samples.
* The CRDs listed in the samples section need spec definitions, but for the moment I've specified an empty spec. From an OpenShift Console perspective, this is provided to users as a "template" or "base" for them to reference when attempting to create an instance of the resource through the GUI.

Scripts have already been published to aws-controllers-k8s/community for automating the process of releasing and subsequently generating a bundle. These scripts leverage this configuration and expect them to exist in the controller repository for each service.

https://github.com/aws-controllers-k8s/community/blob/main/scripts/build-controller-release.sh#L182-L196

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-create-bundle.sh

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-build-bundle-image.sh

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-publish-bundle-image.sh

Assuming you have the aws-controllers-k8s/community repo locally available already, as well as your service controller repository, that process looks something like this for an imaginary "v11.0.0" version:

- Generate bundling assets

```shell
cd community # run all scripts from the 
export ACK_GENERATE_OLM=true
./scripts/build-controller-release.sh apigatewayv2 v11.0.0
```

- Create the bundle on disk

```shell
./scripts/olm-create-bundle.sh apigatewayv2 11.0.0
```

- Publish the bundle to a registry 

```shell
export ADD_RH_CERTIFICATION_LABELS=true
export DOCKER_REPOSITORY=example.com/where/you/are/testing
./scripts/olm-publish-bundle-image.sh apigatewayv2 11.0.0
```

Here's a quick glimpse as to how the ClusterServiceVersion that is generated from this olmconfig gets generated (I used https://operatorhub.io/preview to get this screenshot):

![ack-apigatewayv2-preview](https://user-images.githubusercontent.com/1837593/117218067-17d79180-adc8-11eb-96e8-90bef87c321f.png)
