### PR TITLE
Upgrade to ACK runtime v0.13.0.

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2021-08-17T18:27:26Z"
-  build_hash: 64436ce7e8d7f7356daa6888600a68da4f09a5ac
-  go_version: go1.14.1 darwin/amd64
-  version: v0.11.0
+  build_date: "2021-08-30T19:52:42Z"
+  build_hash: d1d34fc91d8b715ae08a5cef6defe04c623d9918
+  go_version: go1.16.5 linux/amd64
+  version: v0.13.0
 api_directory_checksum: b6d2b18be866a317bf26756b371d24fa26e4d7a2
 api_version: v1alpha1
 aws_sdk_go_version: v1.35.5
@@ -11,4 +11,4 @@ generator_config_info:
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-08-17 18:27:38.192394 +0000 UTC
+  timestamp: 2021-08-30 19:52:51.35816322 +0000 UTC

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/apigatewayv2-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.12.0
+	github.com/aws-controllers-k8s/runtime v0.13.0
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.12.0 h1:G/lCEozh4Brsv1Ojqyl9D/whpq/YvcFtDZBWXf6YIgI=
-github.com/aws-controllers-k8s/runtime v0.12.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.13.0 h1:PYiNnQejjS/1H93bolFXGIzgQZSn/gRoPSAEU6UG0ec=
+github.com/aws-controllers-k8s/runtime v0.13.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -315,7 +315,6 @@ golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -370,14 +369,12 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apigatewayv2-chart
-description: A Helm chart for the ACK service controller for apigatewayv2
-version: v0.0.3
-appVersion: v0.0.3
+description: A Helm chart for the ACK service controller for Amazon API Gateway (APIGWv2)
+version: v0.0.4
+appVersion: v0.0.4
 home: https://github.com/aws-controllers-k8s/apigatewayv2-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:
@@ -10,7 +10,7 @@ sources:
 maintainers:
   - name: ACK Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/ack-admin
-  - name: apigatewayv2 Admins
+  - name: APIGWv2 Admins
     url: https://github.com/orgs/aws-controllers-k8s/teams/apigatewayv2-maintainer
 keywords:
   - aws

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - name: AWS_ENDPOINT_URL
           value: {{ .Values.aws.endpoint_url | quote }}
         - name: ACK_WATCH_NAMESPACE
-          value: {{ include "watch-namespace" . }}   
+          value: {{ include "watch-namespace" . }}
         - name: ACK_ENABLE_DEVELOPMENT_LOGGING
           value: {{ .Values.log.enable_development_logging | quote }}
         - name: ACK_LOG_LEVEL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/apigatewayv2-controller
-  tag: v0.0.3
+  tag: v0.0.4
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -44,12 +44,14 @@ log:
   enable_development_logging: false
   level: info
 
-# Set to "namespace" to install the controller in a namespaced scope, will only watch for object creation 
-# in the namespace. By default installScope is cluster wide.
+# Set to "namespace" to install the controller in a namespaced scope, will only
+# watch for object creation in the namespace. By default installScope is
+# cluster wide.
 installScope: cluster
 
 resourceTags:
-  # Configures the ACK service controller to always set key/value pairs tags on resources that it manages.
+  # Configures the ACK service controller to always set key/value pairs tags on
+  # resources that it manages.
   - services.k8s.aws/managed=true
   - services.k8s.aws/created=%UTCNOW%
   - services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%

--- a/pkg/resource/api/delta.go
+++ b/pkg/resource/api/delta.go
@@ -16,6 +16,7 @@
 package api
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/api/manager.go
+++ b/pkg/resource/api/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/api/resource.go
+++ b/pkg/resource/api/resource.go
@@ -99,3 +99,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/api_mapping/delta.go
+++ b/pkg/resource/api_mapping/delta.go
@@ -16,6 +16,7 @@
 package api_mapping
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/api_mapping/manager.go
+++ b/pkg/resource/api_mapping/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/api_mapping/resource.go
+++ b/pkg/resource/api_mapping/resource.go
@@ -97,10 +97,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.APIMappingID = &identifier.NameOrID
 
-	f0, f0ok := identifier.AdditionalKeys["domainName"]
-	if f0ok {
-		r.ko.Spec.DomainName = &f0
+	f1, f1ok := identifier.AdditionalKeys["domainName"]
+	if f1ok {
+		r.ko.Spec.DomainName = &f1
 	}
 
 	return nil
+}
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
 }

--- a/pkg/resource/authorizer/delta.go
+++ b/pkg/resource/authorizer/delta.go
@@ -16,6 +16,7 @@
 package authorizer
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/authorizer/manager.go
+++ b/pkg/resource/authorizer/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/authorizer/resource.go
+++ b/pkg/resource/authorizer/resource.go
@@ -104,3 +104,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/deployment/delta.go
+++ b/pkg/resource/deployment/delta.go
@@ -16,6 +16,7 @@
 package deployment
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/deployment/manager.go
+++ b/pkg/resource/deployment/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/deployment/resource.go
+++ b/pkg/resource/deployment/resource.go
@@ -104,3 +104,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/domain_name/delta.go
+++ b/pkg/resource/domain_name/delta.go
@@ -16,6 +16,7 @@
 package domain_name
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/domain_name/manager.go
+++ b/pkg/resource/domain_name/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/domain_name/resource.go
+++ b/pkg/resource/domain_name/resource.go
@@ -99,3 +99,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/integration/delta.go
+++ b/pkg/resource/integration/delta.go
@@ -16,6 +16,7 @@
 package integration
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/integration/manager.go
+++ b/pkg/resource/integration/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/integration/resource.go
+++ b/pkg/resource/integration/resource.go
@@ -104,3 +104,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/integration_response/delta.go
+++ b/pkg/resource/integration_response/delta.go
@@ -16,6 +16,7 @@
 package integration_response
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/integration_response/manager.go
+++ b/pkg/resource/integration_response/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/integration_response/resource.go
+++ b/pkg/resource/integration_response/resource.go
@@ -108,3 +108,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/model/delta.go
+++ b/pkg/resource/model/delta.go
@@ -16,6 +16,7 @@
 package model
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/model/manager.go
+++ b/pkg/resource/model/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/model/resource.go
+++ b/pkg/resource/model/resource.go
@@ -104,3 +104,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/route/delta.go
+++ b/pkg/resource/route/delta.go
@@ -16,6 +16,7 @@
 package route
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/route/manager.go
+++ b/pkg/resource/route/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/route/resource.go
+++ b/pkg/resource/route/resource.go
@@ -104,3 +104,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/route_response/delta.go
+++ b/pkg/resource/route_response/delta.go
@@ -16,6 +16,7 @@
 package route_response
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/route_response/manager.go
+++ b/pkg/resource/route_response/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/route_response/resource.go
+++ b/pkg/resource/route_response/resource.go
@@ -108,3 +108,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/stage/delta.go
+++ b/pkg/resource/stage/delta.go
@@ -16,6 +16,7 @@
 package stage
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/stage/manager.go
+++ b/pkg/resource/stage/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/stage/resource.go
+++ b/pkg/resource/stage/resource.go
@@ -104,3 +104,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}

--- a/pkg/resource/vpc_link/delta.go
+++ b/pkg/resource/vpc_link/delta.go
@@ -16,6 +16,7 @@
 package vpc_link
 
 import (
+	"bytes"
 	"reflect"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -23,6 +24,7 @@ import (
 
 // Hack to avoid import errors during build...
 var (
+	_ = &bytes.Buffer{}
 	_ = &reflect.Method{}
 )
 

--- a/pkg/resource/vpc_link/manager.go
+++ b/pkg/resource/vpc_link/manager.go
@@ -190,35 +190,36 @@ func (rm *resourceManager) LateInitialize(
 		rlog.Debug("no late initialization required.")
 		return latest, nil
 	}
+	latestCopy := latest.DeepCopy()
 	lateInitConditionReason := ""
 	lateInitConditionMessage := ""
-	observed, err := rm.ReadOne(ctx, latest)
+	observed, err := rm.ReadOne(ctx, latestCopy)
 	if err != nil {
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, err
+		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return latestCopy, err
 	}
-	latest = rm.lateInitializeFromReadOneOutput(observed, latest)
-	incompleteInitialization := rm.incompleteLateInitialization(latest)
+	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
+	incompleteInitialization := rm.incompleteLateInitialization(lateInitializedRes)
 	if incompleteInitialization {
 		// Add the condition with LateInitialized=False
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
-		ackcondition.SetLateInitialized(latest, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
-		return latest, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
+		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
-	// Set LateIntialized condition to True
+	// Set LateInitialized condition to True
 	lateInitConditionMessage = "Late initialization successful"
 	lateInitConditionReason = "Late initialization successful"
-	ackcondition.SetLateInitialized(latest, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
-	return latest, nil
+	ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionTrue, &lateInitConditionMessage, &lateInitConditionReason)
+	return lateInitializedRes, nil
 }
 
 // incompleteLateInitialization return true if there are fields which were supposed to be
 // late initialized but are not. If all the fields are late initialized, false is returned
 func (rm *resourceManager) incompleteLateInitialization(
-	latest acktypes.AWSResource,
+	res acktypes.AWSResource,
 ) bool {
 	return false
 }

--- a/pkg/resource/vpc_link/resource.go
+++ b/pkg/resource/vpc_link/resource.go
@@ -99,3 +99,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 	return nil
 }
+
+// DeepCopy will return a copy of the resource
+func (r *resource) DeepCopy() acktypes.AWSResource {
+	koCopy := r.ko.DeepCopy()
+	return &resource{koCopy}
+}


### PR DESCRIPTION
Description of changes:
Upgrade ACK runtime to v0.13.0 and regenerate controller using code-generator v0.13.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
