### PR TITLE
upgrade to ack-runtime v0.13.1 and release artifact for v0.0.5 controller release

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2021-08-30T19:52:42Z"
-  build_hash: d1d34fc91d8b715ae08a5cef6defe04c623d9918
-  go_version: go1.16.5 linux/amd64
-  version: v0.13.0
+  build_date: "2021-09-02T19:54:53Z"
+  build_hash: a866a846b883a772c4671061783ccc21a48f9412
+  go_version: go1.14.1 darwin/amd64
+  version: v0.13.1
 api_directory_checksum: b6d2b18be866a317bf26756b371d24fa26e4d7a2
 api_version: v1alpha1
 aws_sdk_go_version: v1.35.5
@@ -11,4 +11,4 @@ generator_config_info:
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-08-30 19:52:51.35816322 +0000 UTC
+  timestamp: 2021-09-02 19:55:06.902381 +0000 UTC

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/apigatewayv2-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.13.0
+	github.com/aws-controllers-k8s/runtime v0.13.1
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.13.0 h1:PYiNnQejjS/1H93bolFXGIzgQZSn/gRoPSAEU6UG0ec=
-github.com/aws-controllers-k8s/runtime v0.13.0/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.13.1 h1:iYVLlC38AVZXXEbNsBhseN+t3zZXtz61GW1LGMhOeTU=
+github.com/aws-controllers-k8s/runtime v0.13.1/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apigatewayv2-chart
 description: A Helm chart for the ACK service controller for Amazon API Gateway (APIGWv2)
-version: v0.0.4
-appVersion: v0.0.4
+version: v0.0.5
+appVersion: v0.0.5
 home: https://github.com/aws-controllers-k8s/apigatewayv2-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/apigatewayv2-controller
-  tag: v0.0.4
+  tag: v0.0.5
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/api/manager.go
+++ b/pkg/resource/api/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/api/sdk.go
+++ b/pkg/resource/api/sdk.go
@@ -619,7 +619,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -642,7 +642,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/api_mapping/manager.go
+++ b/pkg/resource/api_mapping/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/api_mapping/sdk.go
+++ b/pkg/resource/api_mapping/sdk.go
@@ -371,7 +371,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -394,7 +394,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/authorizer/manager.go
+++ b/pkg/resource/authorizer/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/authorizer/sdk.go
+++ b/pkg/resource/authorizer/sdk.go
@@ -613,7 +613,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -636,7 +636,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/deployment/manager.go
+++ b/pkg/resource/deployment/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/deployment/sdk.go
+++ b/pkg/resource/deployment/sdk.go
@@ -392,7 +392,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -415,7 +415,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/domain_name/manager.go
+++ b/pkg/resource/domain_name/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/domain_name/sdk.go
+++ b/pkg/resource/domain_name/sdk.go
@@ -593,7 +593,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -616,7 +616,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/integration/manager.go
+++ b/pkg/resource/integration/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/integration/sdk.go
+++ b/pkg/resource/integration/sdk.go
@@ -754,7 +754,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -777,7 +777,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/integration_response/manager.go
+++ b/pkg/resource/integration_response/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/integration_response/sdk.go
+++ b/pkg/resource/integration_response/sdk.go
@@ -485,7 +485,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -508,7 +508,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/model/manager.go
+++ b/pkg/resource/model/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/model/sdk.go
+++ b/pkg/resource/model/sdk.go
@@ -392,7 +392,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -415,7 +415,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/route/manager.go
+++ b/pkg/resource/route/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/route/sdk.go
+++ b/pkg/resource/route/sdk.go
@@ -654,7 +654,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -677,7 +677,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/route_response/manager.go
+++ b/pkg/resource/route_response/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/route_response/sdk.go
+++ b/pkg/resource/route_response/sdk.go
@@ -474,7 +474,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -497,7 +497,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/stage/manager.go
+++ b/pkg/resource/stage/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/stage/sdk.go
+++ b/pkg/resource/stage/sdk.go
@@ -826,7 +826,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -849,7 +849,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {

--- a/pkg/resource/vpc_link/manager.go
+++ b/pkg/resource/vpc_link/manager.go
@@ -159,7 +159,18 @@ func (rm *resourceManager) Delete(
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	return rm.sdkDelete(ctx, r)
+	observed, err := rm.sdkDelete(ctx, r)
+	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
+		return rm.onError(r, err)
+	}
+
+	if observed != nil {
+		return rm.onSuccess(observed)
+	}
+	return rm.onSuccess(r)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This

--- a/pkg/resource/vpc_link/sdk.go
+++ b/pkg/resource/vpc_link/sdk.go
@@ -503,7 +503,7 @@ func (rm *resourceManager) updateConditions(
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
-			errorMessage = awsErr.Message()
+			errorMessage = awsErr.Error()
 		}
 		terminalCondition.Status = corev1.ConditionTrue
 		terminalCondition.Message = &errorMessage
@@ -526,7 +526,7 @@ func (rm *resourceManager) updateConditions(
 			awsErr, _ := ackerr.AWSError(err)
 			errorMessage := err.Error()
 			if awsErr != nil {
-				errorMessage = awsErr.Message()
+				errorMessage = awsErr.Error()
 			}
 			recoverableCondition.Message = &errorMessage
 		} else if recoverableCondition != nil {


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/894

Description of changes:
* Code generated with latest code-generator v0.13.1
* Updated ack-runtime dependency to v0.13.1
* generated controller with RELEASE_VERSION v0.0.5 which will be the next controller release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
