### PR TITLE
Added node selector for helm chart

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -77,3 +77,4 @@ spec:
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,9 @@ deployment:
   labels: {}
   containerPort: 8080
 
+nodeSelector:
+  kubernetes.io/os: linux
+
 metrics:
   service:
     # Set to true to automatically create a Kubernetes Service resource for the


### PR DESCRIPTION
Issue #, if available:

Description of changes: Added nodSelector label to allow options in case cluster has window and linux nodes. Set default value to linux node.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
