### PR TITLE
Update ACK runtime to v0.14.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ any 'help wanted' issues is a great place to start.
 
 [See the documentation][dev-docs] for detailed development information.
 
-[dev-docs]: https://aws.github.io/aws-controllers-k8s/dev-docs/overview/
+[dev-docs]: https://aws-controllers-k8s.github.io/community/docs/contributor-docs/overview/
 
 ## Code of Conduct
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,13 @@
 ack_generate_info:
-  build_date: "2021-09-02T19:54:53Z"
-  build_hash: a866a846b883a772c4671061783ccc21a48f9412
-  go_version: go1.14.1 darwin/amd64
-  version: v0.13.1
-api_directory_checksum: b6d2b18be866a317bf26756b371d24fa26e4d7a2
+  build_date: "2021-09-23T17:44:12Z"
+  build_hash: e4d7c2aabd8113176b0662bb3d31751914e2c5e9
+  go_version: go1.16.5
+  version: v0.14.1
+api_directory_checksum: 20625534fa65e1e856fc014ab5de111bbc23bf57
 api_version: v1alpha1
-aws_sdk_go_version: v1.35.5
+aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: 9d648ce9cb26d1572db8e54e82f052f25fa8f92a
+  file_checksum: df7c7fbb497f119ebacb994cab1b242d67dcc201
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-09-02 19:55:06.902381 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -19,8 +19,15 @@ resources:
         is_required: false
     update_operation:
       custom_method_name: customUpdateApi
+  DomainName:
+    fields:
+      DomainName:
+        is_primary_key: true
+        is_required: true
+        from:
+          operation: CreateDomainName
+          path: DomainName
 operations:
   CreateApi:
     custom_implementation: customCreateApi
-  GetDomainName:
-    primary_identifier_field_name: DomainName
+

--- a/apis/v1alpha1/integration.go
+++ b/apis/v1alpha1/integration.go
@@ -55,6 +55,8 @@ type IntegrationSpec struct {
 
 	RequestTemplates map[string]*string `json:"requestTemplates,omitempty"`
 
+	ResponseParameters map[string]map[string]*string `json:"responseParameters,omitempty"`
+
 	TemplateSelectionExpression *string `json:"templateSelectionExpression,omitempty"`
 
 	TimeoutInMillis *int64 `json:"timeoutInMillis,omitempty"`

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -211,16 +211,28 @@ type IntegrationResponse_SDK struct {
 	// for a list of expressions and each expression's associated selection key
 	// type.
 	IntegrationResponseKey *string `json:"integrationResponseKey,omitempty"`
-	// A key-value map specifying response parameters that are passed to the method
-	// response from the backend. The key is a method response header parameter
-	// name and the mapped value is an integration response header value, a static
-	// value enclosed within a pair of single quotes, or a JSON expression from
-	// the integration response body. The mapping key must match the pattern of
-	// method.response.header.{name}, where name is a valid and unique header name.
-	// The mapped non-static value must match the pattern of integration.response.header.{name}
-	// or integration.response.body.{JSON-expression}, where name is a valid and
-	// unique response header name and JSON-expression is a valid JSON expression
-	// without the $ prefix.
+	// For WebSocket APIs, a key-value map specifying request parameters that are
+	// passed from the method request to the backend. The key is an integration
+	// request parameter name and the associated value is a method request parameter
+	// value or static value that must be enclosed within single quotes and pre-encoded
+	// as required by the backend. The method request parameter value must match
+	// the pattern of method.request.{location}.{name} , where {location} is querystring,
+	// path, or header; and {name} must be a valid and unique method request parameter
+	// name.
+	//
+	// For HTTP API integrations with a specified integrationSubtype, request parameters
+	// are a key-value map specifying parameters that are passed to AWS_PROXY integrations.
+	// You can provide static values, or map request data, stage variables, or context
+	// variables that are evaluated at runtime. To learn more, see Working with
+	// AWS service integrations for HTTP APIs (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html).
+	//
+	// For HTTP API integrations without a specified integrationSubtype request
+	// parameters are a key-value map specifying how to transform HTTP requests
+	// before sending them to the backend. The key should follow the pattern <action>:<header|querystring|path>.<location>
+	// where action can be append, overwrite or remove. For values, you can provide
+	// static values, or map request data, stage variables, or context variables
+	// that are evaluated at runtime. To learn more, see Transforming API requests
+	// and responses (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html).
 	ResponseParameters map[string]*string `json:"responseParameters,omitempty"`
 	// A mapping of identifier keys to templates. The value is an actual template
 	// script. The key is typically a SelectionKey which is chosen based on evaluating
@@ -265,21 +277,37 @@ type Integration_SDK struct {
 	PassthroughBehavior *string `json:"passthroughBehavior,omitempty"`
 	// A string with a length between [1-64].
 	PayloadFormatVersion *string `json:"payloadFormatVersion,omitempty"`
-	// A key-value map specifying response parameters that are passed to the method
-	// response from the backend. The key is a method response header parameter
-	// name and the mapped value is an integration response header value, a static
-	// value enclosed within a pair of single quotes, or a JSON expression from
-	// the integration response body. The mapping key must match the pattern of
-	// method.response.header.{name}, where name is a valid and unique header name.
-	// The mapped non-static value must match the pattern of integration.response.header.{name}
-	// or integration.response.body.{JSON-expression}, where name is a valid and
-	// unique response header name and JSON-expression is a valid JSON expression
-	// without the $ prefix.
+	// For WebSocket APIs, a key-value map specifying request parameters that are
+	// passed from the method request to the backend. The key is an integration
+	// request parameter name and the associated value is a method request parameter
+	// value or static value that must be enclosed within single quotes and pre-encoded
+	// as required by the backend. The method request parameter value must match
+	// the pattern of method.request.{location}.{name} , where {location} is querystring,
+	// path, or header; and {name} must be a valid and unique method request parameter
+	// name.
+	//
+	// For HTTP API integrations with a specified integrationSubtype, request parameters
+	// are a key-value map specifying parameters that are passed to AWS_PROXY integrations.
+	// You can provide static values, or map request data, stage variables, or context
+	// variables that are evaluated at runtime. To learn more, see Working with
+	// AWS service integrations for HTTP APIs (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html).
+	//
+	// For HTTP API integrations without a specified integrationSubtype request
+	// parameters are a key-value map specifying how to transform HTTP requests
+	// before sending them to the backend. The key should follow the pattern <action>:<header|querystring|path>.<location>
+	// where action can be append, overwrite or remove. For values, you can provide
+	// static values, or map request data, stage variables, or context variables
+	// that are evaluated at runtime. To learn more, see Transforming API requests
+	// and responses (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-parameter-mapping.html).
 	RequestParameters map[string]*string `json:"requestParameters,omitempty"`
 	// A mapping of identifier keys to templates. The value is an actual template
 	// script. The key is typically a SelectionKey which is chosen based on evaluating
 	// a selection expression.
 	RequestTemplates map[string]*string `json:"requestTemplates,omitempty"`
+	// Supported only for HTTP APIs. You use response parameters to transform the
+	// HTTP response from a backend integration before returning the response to
+	// clients.
+	ResponseParameters map[string]map[string]*string `json:"responseParameters,omitempty"`
 	// An expression used to extract information at runtime. See Selection Expressions
 	// (https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions)
 	// for more information.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1713,6 +1713,31 @@ func (in *IntegrationSpec) DeepCopyInto(out *IntegrationSpec) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.ResponseParameters != nil {
+		in, out := &in.ResponseParameters, &out.ResponseParameters
+		*out = make(map[string]map[string]*string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]*string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(map[string]*string, len(*in))
+				for key, val := range *in {
+					var outVal *string
+					if val == nil {
+						(*out)[key] = nil
+					} else {
+						in, out := &val, &outVal
+						*out = new(string)
+						**out = **in
+					}
+					(*out)[key] = outVal
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	if in.TemplateSelectionExpression != nil {
 		in, out := &in.TemplateSelectionExpression, &out.TemplateSelectionExpression
 		*out = new(string)
@@ -1885,6 +1910,31 @@ func (in *Integration_SDK) DeepCopyInto(out *Integration_SDK) {
 				in, out := &val, &outVal
 				*out = new(string)
 				**out = **in
+			}
+			(*out)[key] = outVal
+		}
+	}
+	if in.ResponseParameters != nil {
+		in, out := &in.ResponseParameters, &out.ResponseParameters
+		*out = make(map[string]map[string]*string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]*string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(map[string]*string, len(*in))
+				for key, val := range *in {
+					var outVal *string
+					if val == nil {
+						(*out)[key] = nil
+					} else {
+						in, out := &val, &outVal
+						*out = new(string)
+						**out = **in
+					}
+					(*out)[key] = outVal
+				}
 			}
 			(*out)[key] = outVal
 		}

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -41,7 +41,8 @@ spec:
         image: controller:latest
         name: controller
         ports:
-          - containerPort: 8080
+          - name: http
+            containerPort: 8080
         resources:
           limits:
             cpu: 100m

--- a/config/controller/service.yaml
+++ b/config/controller/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - name: metricsport
       port: 8080
-      targetPort: 8080
+      targetPort: http
       protocol: TCP
   type: NodePort

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_apimappings.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_apimappings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: apimappings.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: apis.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: authorizers.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: deployments.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_domainnames.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_domainnames.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: domainnames.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_integrationresponses.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_integrationresponses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: integrationresponses.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: integrations.apigatewayv2.services.k8s.aws
 spec:
@@ -68,6 +68,12 @@ spec:
               requestTemplates:
                 additionalProperties:
                   type: string
+                type: object
+              responseParameters:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
                 type: object
               templateSelectionExpression:
                 type: string

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_models.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_models.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: models.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_routeresponses.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_routeresponses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: routeresponses.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: routes.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: stages.apigatewayv2.services.k8s.aws
 spec:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_vpclinks.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_vpclinks.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: vpclinks.apigatewayv2.services.k8s.aws
 spec:

--- a/generator.yaml
+++ b/generator.yaml
@@ -19,8 +19,15 @@ resources:
         is_required: false
     update_operation:
       custom_method_name: customUpdateApi
+  DomainName:
+    fields:
+      DomainName:
+        is_primary_key: true
+        is_required: true
+        from:
+          operation: CreateDomainName
+          path: DomainName
 operations:
   CreateApi:
     custom_implementation: customCreateApi
-  GetDomainName:
-    primary_identifier_field_name: DomainName
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/apigatewayv2-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.13.1
+	github.com/aws-controllers-k8s/runtime v0.14.1
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.13.1 h1:iYVLlC38AVZXXEbNsBhseN+t3zZXtz61GW1LGMhOeTU=
-github.com/aws-controllers-k8s/runtime v0.13.1/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.14.1 h1:2/hCwost9rmtgsgktCtJH75U74ziWiBs0bHFOB2iaKo=
+github.com/aws-controllers-k8s/runtime v0.14.1/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/helm/crds/apigatewayv2.services.k8s.aws_apimappings.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_apimappings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: apimappings.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_apis.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: apis.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: authorizers.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: deployments.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_domainnames.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_domainnames.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: domainnames.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_integrationresponses.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_integrationresponses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: integrationresponses.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: integrations.apigatewayv2.services.k8s.aws
 spec:
@@ -68,6 +68,12 @@ spec:
               requestTemplates:
                 additionalProperties:
                   type: string
+                type: object
+              responseParameters:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
                 type: object
               templateSelectionExpression:
                 type: string

--- a/helm/crds/apigatewayv2.services.k8s.aws_models.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_models.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: models.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_routeresponses.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_routeresponses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: routeresponses.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_routes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: routes.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_stages.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: stages.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/apigatewayv2.services.k8s.aws_vpclinks.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_vpclinks.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: vpclinks.apigatewayv2.services.k8s.aws
 spec:

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: adoptedresources.services.k8s.aws
 spec:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -54,7 +54,8 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: controller
         ports:
-          - containerPort: {{ .Values.deployment.containerPort }}
+          - name: http
+            containerPort: {{ .Values.deployment.containerPort }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:
@@ -77,3 +78,4 @@ spec:
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10
+      nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "app.fullname" . }}-metrics
+  name: {{ .Chart.Name | trimSuffix "-chart" | trunc 44 }}-controller-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "app.name" . }}
@@ -25,6 +25,6 @@ spec:
   ports:
   - name: metricsport
     port: 8080
-    targetPort: 8080
+    targetPort: http
     protocol: TCP
 {{- end }}

--- a/helm/templates/service-account.yaml
+++ b/helm/templates/service-account.yaml
@@ -10,6 +10,7 @@ metadata:
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
   name: {{ include "service-account.name" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- range $key, $value := .Values.serviceAccount.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,8 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+  nodeSelector:
+    kubernetes.io/os: linux
 
 metrics:
   service:

--- a/pkg/resource/api/manager.go
+++ b/pkg/resource/api/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/api/resource.go
+++ b/pkg/resource/api/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/api/sdk.go
+++ b/pkg/resource/api/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.API{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/api_mapping/manager.go
+++ b/pkg/resource/api_mapping/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/api_mapping/resource.go
+++ b/pkg/resource/api_mapping/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/api_mapping/sdk.go
+++ b/pkg/resource/api_mapping/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.APIMapping{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/authorizer/manager.go
+++ b/pkg/resource/authorizer/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/authorizer/resource.go
+++ b/pkg/resource/authorizer/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/authorizer/sdk.go
+++ b/pkg/resource/authorizer/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.Authorizer{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/deployment/manager.go
+++ b/pkg/resource/deployment/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/deployment/resource.go
+++ b/pkg/resource/deployment/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/deployment/sdk.go
+++ b/pkg/resource/deployment/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.Deployment{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/domain_name/manager.go
+++ b/pkg/resource/domain_name/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/domain_name/resource.go
+++ b/pkg/resource/domain_name/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/domain_name/sdk.go
+++ b/pkg/resource/domain_name/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.DomainName{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/integration/delta.go
+++ b/pkg/resource/integration/delta.go
@@ -139,6 +139,13 @@ func newResourceDelta(
 			delta.Add("Spec.RequestTemplates", a.ko.Spec.RequestTemplates, b.ko.Spec.RequestTemplates)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.ResponseParameters, b.ko.Spec.ResponseParameters) {
+		delta.Add("Spec.ResponseParameters", a.ko.Spec.ResponseParameters, b.ko.Spec.ResponseParameters)
+	} else if a.ko.Spec.ResponseParameters != nil && b.ko.Spec.ResponseParameters != nil {
+		if !reflect.DeepEqual(a.ko.Spec.ResponseParameters, b.ko.Spec.ResponseParameters) {
+			delta.Add("Spec.ResponseParameters", a.ko.Spec.ResponseParameters, b.ko.Spec.ResponseParameters)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TemplateSelectionExpression, b.ko.Spec.TemplateSelectionExpression) {
 		delta.Add("Spec.TemplateSelectionExpression", a.ko.Spec.TemplateSelectionExpression, b.ko.Spec.TemplateSelectionExpression)
 	} else if a.ko.Spec.TemplateSelectionExpression != nil && b.ko.Spec.TemplateSelectionExpression != nil {

--- a/pkg/resource/integration/manager.go
+++ b/pkg/resource/integration/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/integration/resource.go
+++ b/pkg/resource/integration/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/integration/sdk.go
+++ b/pkg/resource/integration/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.Integration{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -168,6 +170,21 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Spec.RequestTemplates = nil
 	}
+	if resp.ResponseParameters != nil {
+		f16 := map[string]map[string]*string{}
+		for f16key, f16valiter := range resp.ResponseParameters {
+			f16val := map[string]*string{}
+			for f16valkey, f16valvaliter := range f16valiter {
+				var f16valval string
+				f16valval = *f16valvaliter
+				f16val[f16valkey] = &f16valval
+			}
+			f16[f16key] = f16val
+		}
+		ko.Spec.ResponseParameters = f16
+	} else {
+		ko.Spec.ResponseParameters = nil
+	}
 	if resp.TemplateSelectionExpression != nil {
 		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	} else {
@@ -179,11 +196,11 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.TimeoutInMillis = nil
 	}
 	if resp.TlsConfig != nil {
-		f18 := &svcapitypes.TLSConfigInput{}
+		f19 := &svcapitypes.TLSConfigInput{}
 		if resp.TlsConfig.ServerNameToVerify != nil {
-			f18.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
+			f19.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
 		}
-		ko.Spec.TLSConfig = f18
+		ko.Spec.TLSConfig = f19
 	} else {
 		ko.Spec.TLSConfig = nil
 	}
@@ -337,6 +354,21 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Spec.RequestTemplates = nil
 	}
+	if resp.ResponseParameters != nil {
+		f16 := map[string]map[string]*string{}
+		for f16key, f16valiter := range resp.ResponseParameters {
+			f16val := map[string]*string{}
+			for f16valkey, f16valvaliter := range f16valiter {
+				var f16valval string
+				f16valval = *f16valvaliter
+				f16val[f16valkey] = &f16valval
+			}
+			f16[f16key] = f16val
+		}
+		ko.Spec.ResponseParameters = f16
+	} else {
+		ko.Spec.ResponseParameters = nil
+	}
 	if resp.TemplateSelectionExpression != nil {
 		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	} else {
@@ -348,11 +380,11 @@ func (rm *resourceManager) sdkCreate(
 		ko.Spec.TimeoutInMillis = nil
 	}
 	if resp.TlsConfig != nil {
-		f18 := &svcapitypes.TLSConfigInput{}
+		f19 := &svcapitypes.TLSConfigInput{}
 		if resp.TlsConfig.ServerNameToVerify != nil {
-			f18.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
+			f19.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
 		}
-		ko.Spec.TLSConfig = f18
+		ko.Spec.TLSConfig = f19
 	} else {
 		ko.Spec.TLSConfig = nil
 	}
@@ -423,6 +455,19 @@ func (rm *resourceManager) newCreateRequestPayload(
 		}
 		res.SetRequestTemplates(f13)
 	}
+	if r.ko.Spec.ResponseParameters != nil {
+		f14 := map[string]map[string]*string{}
+		for f14key, f14valiter := range r.ko.Spec.ResponseParameters {
+			f14val := map[string]*string{}
+			for f14valkey, f14valvaliter := range f14valiter {
+				var f14valval string
+				f14valval = *f14valvaliter
+				f14val[f14valkey] = &f14valval
+			}
+			f14[f14key] = f14val
+		}
+		res.SetResponseParameters(f14)
+	}
 	if r.ko.Spec.TemplateSelectionExpression != nil {
 		res.SetTemplateSelectionExpression(*r.ko.Spec.TemplateSelectionExpression)
 	}
@@ -430,11 +475,11 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetTimeoutInMillis(*r.ko.Spec.TimeoutInMillis)
 	}
 	if r.ko.Spec.TLSConfig != nil {
-		f16 := &svcsdk.TlsConfigInput{}
+		f17 := &svcsdk.TlsConfigInput{}
 		if r.ko.Spec.TLSConfig.ServerNameToVerify != nil {
-			f16.SetServerNameToVerify(*r.ko.Spec.TLSConfig.ServerNameToVerify)
+			f17.SetServerNameToVerify(*r.ko.Spec.TLSConfig.ServerNameToVerify)
 		}
-		res.SetTlsConfig(f16)
+		res.SetTlsConfig(f17)
 	}
 
 	return res, nil
@@ -559,6 +604,21 @@ func (rm *resourceManager) sdkUpdate(
 	} else {
 		ko.Spec.RequestTemplates = nil
 	}
+	if resp.ResponseParameters != nil {
+		f16 := map[string]map[string]*string{}
+		for f16key, f16valiter := range resp.ResponseParameters {
+			f16val := map[string]*string{}
+			for f16valkey, f16valvaliter := range f16valiter {
+				var f16valval string
+				f16valval = *f16valvaliter
+				f16val[f16valkey] = &f16valval
+			}
+			f16[f16key] = f16val
+		}
+		ko.Spec.ResponseParameters = f16
+	} else {
+		ko.Spec.ResponseParameters = nil
+	}
 	if resp.TemplateSelectionExpression != nil {
 		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	} else {
@@ -570,11 +630,11 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Spec.TimeoutInMillis = nil
 	}
 	if resp.TlsConfig != nil {
-		f18 := &svcapitypes.TLSConfigInput{}
+		f19 := &svcapitypes.TLSConfigInput{}
 		if resp.TlsConfig.ServerNameToVerify != nil {
-			f18.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
+			f19.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
 		}
-		ko.Spec.TLSConfig = f18
+		ko.Spec.TLSConfig = f19
 	} else {
 		ko.Spec.TLSConfig = nil
 	}
@@ -648,6 +708,19 @@ func (rm *resourceManager) newUpdateRequestPayload(
 		}
 		res.SetRequestTemplates(f14)
 	}
+	if r.ko.Spec.ResponseParameters != nil {
+		f15 := map[string]map[string]*string{}
+		for f15key, f15valiter := range r.ko.Spec.ResponseParameters {
+			f15val := map[string]*string{}
+			for f15valkey, f15valvaliter := range f15valiter {
+				var f15valval string
+				f15valval = *f15valvaliter
+				f15val[f15valkey] = &f15valval
+			}
+			f15[f15key] = f15val
+		}
+		res.SetResponseParameters(f15)
+	}
 	if r.ko.Spec.TemplateSelectionExpression != nil {
 		res.SetTemplateSelectionExpression(*r.ko.Spec.TemplateSelectionExpression)
 	}
@@ -655,11 +728,11 @@ func (rm *resourceManager) newUpdateRequestPayload(
 		res.SetTimeoutInMillis(*r.ko.Spec.TimeoutInMillis)
 	}
 	if r.ko.Spec.TLSConfig != nil {
-		f17 := &svcsdk.TlsConfigInput{}
+		f18 := &svcsdk.TlsConfigInput{}
 		if r.ko.Spec.TLSConfig.ServerNameToVerify != nil {
-			f17.SetServerNameToVerify(*r.ko.Spec.TLSConfig.ServerNameToVerify)
+			f18.SetServerNameToVerify(*r.ko.Spec.TLSConfig.ServerNameToVerify)
 		}
-		res.SetTlsConfig(f17)
+		res.SetTlsConfig(f18)
 	}
 
 	return res, nil

--- a/pkg/resource/integration_response/manager.go
+++ b/pkg/resource/integration_response/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/integration_response/resource.go
+++ b/pkg/resource/integration_response/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/integration_response/sdk.go
+++ b/pkg/resource/integration_response/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.IntegrationResponse{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/model/manager.go
+++ b/pkg/resource/model/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/model/resource.go
+++ b/pkg/resource/model/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/model/sdk.go
+++ b/pkg/resource/model/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.Model{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/route/manager.go
+++ b/pkg/resource/route/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/route/resource.go
+++ b/pkg/resource/route/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/route/sdk.go
+++ b/pkg/resource/route/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.Route{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/route_response/manager.go
+++ b/pkg/resource/route_response/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/route_response/resource.go
+++ b/pkg/resource/route_response/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/route_response/sdk.go
+++ b/pkg/resource/route_response/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.RouteResponse{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/stage/manager.go
+++ b/pkg/resource/stage/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/stage/resource.go
+++ b/pkg/resource/stage/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/stage/sdk.go
+++ b/pkg/resource/stage/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.Stage{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/vpc_link/manager.go
+++ b/pkg/resource/vpc_link/manager.go
@@ -167,10 +167,7 @@ func (rm *resourceManager) Delete(
 		return rm.onError(r, err)
 	}
 
-	if observed != nil {
-		return rm.onSuccess(observed)
-	}
-	return rm.onSuccess(r)
+	return rm.onSuccess(observed)
 }
 
 // ARNFromName returns an AWS Resource Name from a given string name. This
@@ -273,6 +270,9 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, err
+	}
 	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
@@ -293,6 +293,9 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
+	if r == nil {
+		return nil, nil
+	}
 	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil

--- a/pkg/resource/vpc_link/resource.go
+++ b/pkg/resource/vpc_link/resource.go
@@ -59,7 +59,7 @@ func (r *resource) RuntimeObject() k8srt.Object {
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
 func (r *resource) MetaObject() metav1.Object {
-	return r.ko
+	return r.ko.GetObjectMeta()
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes

--- a/pkg/resource/vpc_link/sdk.go
+++ b/pkg/resource/vpc_link/sdk.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,7 @@ var (
 	_ = &svcapitypes.VPCLink{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = &ackcondition.NotManagedMessage
 )
 
 // sdkFind returns SDK-specific information about a supplied resource


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/951

Description of changes:
* Fixing the generator.yaml so that apigatewayv2-controller can be auto-generated on next code-gen release.
* Successfully generated and tested controller locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
