### PR TITLE
ignore deploymentid when updating stage with autodeploy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-09-26T23:12:25Z"
-  build_hash: 2b0ac062dd6d305434d252b5da5ed718c801b106
+  build_date: "2021-10-25T21:43:55Z"
+  build_hash: f37b8ea9fcc401d66018d7849e8c809da5b4c99c
   go_version: go1.16.5
-  version: v0.14.1
+  version: v0.15.1
 api_directory_checksum: 20625534fa65e1e856fc014ab5de111bbc23bf57
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: df7c7fbb497f119ebacb994cab1b242d67dcc201
+  file_checksum: 341fa96adbf9a1c7319dff1e73b67d98839cb2b2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -27,6 +27,10 @@ resources:
         from:
           operation: CreateDomainName
           path: DomainName
+  Stage:
+    hooks:
+      sdk_update_post_build_request:
+        template_path: hooks/stage/sdk_update_post_build_request.go.tpl
 operations:
   CreateApi:
     custom_implementation: customCreateApi

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -26,8 +26,6 @@ spec:
       - command:
         - ./bin/controller
         args:
-        - --aws-account-id
-        - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
         - --enable-development-logging

--- a/generator.yaml
+++ b/generator.yaml
@@ -27,6 +27,10 @@ resources:
         from:
           operation: CreateDomainName
           path: DomainName
+  Stage:
+    hooks:
+      sdk_update_post_build_request:
+        template_path: hooks/stage/sdk_update_post_build_request.go.tpl
 operations:
   CreateApi:
     custom_implementation: customCreateApi

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/apigatewayv2-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.14.1
+	github.com/aws-controllers-k8s/runtime v0.15.1
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.14.1 h1:2/hCwost9rmtgsgktCtJH75U74ziWiBs0bHFOB2iaKo=
-github.com/aws-controllers-k8s/runtime v0.14.1/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.15.1 h1:3P+6MKWe8ITJynmoxmDnMPlkoI9nuVgn8XD9Pt/XHE8=
+github.com/aws-controllers-k8s/runtime v0.15.1/go.mod h1:W0Txdhb1Npx5kg72w2WFwIpGFvSsMxXlJzzNHAwCLeY=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -179,6 +179,8 @@ github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jaypipes/envutil v1.0.0 h1:u6Vwy9HwruFihoZrL0bxDLCa/YNadGVwKyPElNmZWow=
+github.com/jaypipes/envutil v1.0.0/go.mod h1:vgIRDly+xgBq0eeZRcflOHMMobMwgC6MkMbxo/Nw65M=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apigatewayv2-chart
 description: A Helm chart for the ACK service controller for Amazon API Gateway (APIGWv2)
-version: v0.0.6
-appVersion: v0.0.6
+version: v0.0.7
+appVersion: v0.0.7
 home: https://github.com/aws-controllers-k8s/apigatewayv2-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
       - command:
         - ./bin/controller
         args:
-        - --aws-account-id
-        - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
         - --aws-endpoint-url
@@ -63,8 +61,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: AWS_ACCOUNT_ID
-          value: {{ .Values.aws.account_id | quote }}
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/apigatewayv2-controller
-  tag: v0.0.6
+  tag: v0.0.7
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -38,7 +38,6 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
-  account_id: ""
   endpoint_url: ""
 
 # log level for the controller

--- a/pkg/resource/api/descriptor.go
+++ b/pkg/resource/api/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("apis")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "API",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/api_mapping/descriptor.go
+++ b/pkg/resource/api_mapping/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("apimappings")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "APIMapping",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/authorizer/descriptor.go
+++ b/pkg/resource/authorizer/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("authorizers")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "Authorizer",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/deployment/descriptor.go
+++ b/pkg/resource/deployment/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("deployments")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "Deployment",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/domain_name/descriptor.go
+++ b/pkg/resource/domain_name/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("domainnames")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "DomainName",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/integration/descriptor.go
+++ b/pkg/resource/integration/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("integrations")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "Integration",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/integration_response/descriptor.go
+++ b/pkg/resource/integration_response/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("integrationresponses")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "IntegrationResponse",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model/descriptor.go
+++ b/pkg/resource/model/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("models")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "Model",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/route/descriptor.go
+++ b/pkg/resource/route/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("routes")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "Route",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/route_response/descriptor.go
+++ b/pkg/resource/route_response/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("routeresponses")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "RouteResponse",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/stage/descriptor.go
+++ b/pkg/resource/stage/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("stages")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "Stage",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/stage/sdk.go
+++ b/pkg/resource/stage/sdk.go
@@ -506,6 +506,10 @@ func (rm *resourceManager) sdkUpdate(
 	if err != nil {
 		return nil, err
 	}
+	// Ignore deploymentId when autodeploy is set to true
+	if *input.AutoDeploy == true {
+		input.DeploymentId = nil
+	}
 
 	var resp *svcsdk.UpdateStageOutput
 	_ = resp

--- a/pkg/resource/vpc_link/descriptor.go
+++ b/pkg/resource/vpc_link/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("vpclinks")
+	GroupKind            = metav1.GroupKind{
 		Group: "apigatewayv2.services.k8s.aws",
 		Kind:  "VPCLink",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/templates/hooks/stage/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/stage/sdk_update_post_build_request.go.tpl
@@ -1,0 +1,4 @@
+    // Ignore deploymentId when autodeploy is set to true
+    if *input.AutoDeploy == true {
+        input.DeploymentId = nil
+    }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1033

Description of changes:
* Avoid BadRequestException when updating stage with autodeploy 'true'
* DeploymentId is present in desired resource after ReadOne call but it should not be set when updating stage with autodeploy=true
* update ACK runtime version to v0.15.1
* Generate release artifacts for v0.0.7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
