### PR TITLE
Add resource references and e2e tests

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-03-03T00:08:42Z"
+  build_date: "2022-03-03T00:37:31Z"
   build_hash: ade2429bb444ab635916395ea5773d141ba135e1
   go_version: go1.17.5
   version: v0.17.2
-api_directory_checksum: b98cf468e3704663b922b51293db3aab00e16cbc
+api_directory_checksum: c69d75f37400a8d4d6eb4362eb743005531a7b2c
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 21136a68fd8323e233a0f579b52126998a12e378
+  file_checksum: 6ea111ed6683ab7ee07ffd165ae76454bd0fddab
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/authorizer.go
+++ b/apis/v1alpha1/authorizer.go
@@ -24,9 +24,8 @@ import (
 //
 // Represents an authorizer.
 type AuthorizerSpec struct {
-
-	// +kubebuilder:validation:Required
-	APIID *string `json:"apiID"`
+	APIID  *string                                  `json:"apiID,omitempty"`
+	APIRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"apiRef,omitempty"`
 
 	AuthorizerCredentialsARN *string `json:"authorizerCredentialsARN,omitempty"`
 

--- a/apis/v1alpha1/deployment.go
+++ b/apis/v1alpha1/deployment.go
@@ -25,9 +25,8 @@ import (
 // An immutable representation of an API that can be called by users. A Deployment
 // must be associated with a Stage for it to be callable over the internet.
 type DeploymentSpec struct {
-
-	// +kubebuilder:validation:Required
-	APIID *string `json:"apiID"`
+	APIID  *string                                  `json:"apiID,omitempty"`
+	APIRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"apiRef,omitempty"`
 
 	Description *string `json:"description,omitempty"`
 

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,54 @@ resources:
     hooks:
       sdk_update_post_build_request:
         template_path: hooks/stage/sdk_update_post_build_request.go.tpl
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+      DeploymentId:
+        references:
+          resource: Deployment
+          path: Status.DeploymentID
+  Authorizer:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+  Deployment:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+  Integration:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+      ConnectionId:
+        references:
+          resource: VPCLink
+          path: Status.VPCLinkID
+  Route:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+      AuthorizerId:
+        references:
+          resource: Authorizer
+          path: Status.AuthorizerID
+      Target:
+        references:
+          resource: Integration
+          path: Status.IntegrationID
+    hooks:
+      references_post_resolve:
+        template_path: hooks/route/references_post_resolve.go.tpl
   VpcLink:
     hooks:
       sdk_update_pre_build_request:

--- a/apis/v1alpha1/integration.go
+++ b/apis/v1alpha1/integration.go
@@ -24,11 +24,11 @@ import (
 //
 // Represents an integration.
 type IntegrationSpec struct {
+	APIID  *string                                  `json:"apiID,omitempty"`
+	APIRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"apiRef,omitempty"`
 
-	// +kubebuilder:validation:Required
-	APIID *string `json:"apiID"`
-
-	ConnectionID *string `json:"connectionID,omitempty"`
+	ConnectionID  *string                                  `json:"connectionID,omitempty"`
+	ConnectionRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"connectionRef,omitempty"`
 
 	ConnectionType *string `json:"connectionType,omitempty"`
 

--- a/apis/v1alpha1/route.go
+++ b/apis/v1alpha1/route.go
@@ -24,17 +24,17 @@ import (
 //
 // Represents a route.
 type RouteSpec struct {
+	APIID *string `json:"apiID,omitempty"`
 
-	// +kubebuilder:validation:Required
-	APIID *string `json:"apiID"`
-
-	APIKeyRequired *bool `json:"apiKeyRequired,omitempty"`
+	APIKeyRequired *bool                                    `json:"apiKeyRequired,omitempty"`
+	APIRef         *ackv1alpha1.AWSResourceReferenceWrapper `json:"apiRef,omitempty"`
 
 	AuthorizationScopes []*string `json:"authorizationScopes,omitempty"`
 
 	AuthorizationType *string `json:"authorizationType,omitempty"`
 
-	AuthorizerID *string `json:"authorizerID,omitempty"`
+	AuthorizerID  *string                                  `json:"authorizerID,omitempty"`
+	AuthorizerRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"authorizerRef,omitempty"`
 
 	ModelSelectionExpression *string `json:"modelSelectionExpression,omitempty"`
 
@@ -49,7 +49,8 @@ type RouteSpec struct {
 
 	RouteResponseSelectionExpression *string `json:"routeResponseSelectionExpression,omitempty"`
 
-	Target *string `json:"target,omitempty"`
+	Target    *string                                  `json:"target,omitempty"`
+	TargetRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetRef,omitempty"`
 }
 
 // RouteStatus defines the observed state of Route

--- a/apis/v1alpha1/stage.go
+++ b/apis/v1alpha1/stage.go
@@ -26,8 +26,8 @@ import (
 type StageSpec struct {
 	AccessLogSettings *AccessLogSettings `json:"accessLogSettings,omitempty"`
 
-	// +kubebuilder:validation:Required
-	APIID *string `json:"apiID"`
+	APIID  *string                                  `json:"apiID,omitempty"`
+	APIRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"apiRef,omitempty"`
 
 	AutoDeploy *bool `json:"autoDeploy,omitempty"`
 
@@ -35,7 +35,8 @@ type StageSpec struct {
 
 	DefaultRouteSettings *RouteSettings `json:"defaultRouteSettings,omitempty"`
 
-	DeploymentID *string `json:"deploymentID,omitempty"`
+	DeploymentID  *string                                  `json:"deploymentID,omitempty"`
+	DeploymentRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"deploymentRef,omitempty"`
 
 	Description *string `json:"description,omitempty"`
 

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -504,6 +504,11 @@ func (in *AuthorizerSpec) DeepCopyInto(out *AuthorizerSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.APIRef != nil {
+		in, out := &in.APIRef, &out.APIRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AuthorizerCredentialsARN != nil {
 		in, out := &in.AuthorizerCredentialsARN, &out.AuthorizerCredentialsARN
 		*out = new(string)
@@ -819,6 +824,11 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 		in, out := &in.APIID, &out.APIID
 		*out = new(string)
 		**out = **in
+	}
+	if in.APIRef != nil {
+		in, out := &in.APIRef, &out.APIRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Description != nil {
 		in, out := &in.Description, &out.Description
@@ -1162,10 +1172,20 @@ func (in *IntegrationSpec) DeepCopyInto(out *IntegrationSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.APIRef != nil {
+		in, out := &in.APIRef, &out.APIRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ConnectionID != nil {
 		in, out := &in.ConnectionID, &out.ConnectionID
 		*out = new(string)
 		**out = **in
+	}
+	if in.ConnectionRef != nil {
+		in, out := &in.ConnectionRef, &out.ConnectionRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ConnectionType != nil {
 		in, out := &in.ConnectionType, &out.ConnectionType
@@ -1819,6 +1839,11 @@ func (in *RouteSpec) DeepCopyInto(out *RouteSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.APIRef != nil {
+		in, out := &in.APIRef, &out.APIRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AuthorizationScopes != nil {
 		in, out := &in.AuthorizationScopes, &out.AuthorizationScopes
 		*out = make([]*string, len(*in))
@@ -1839,6 +1864,11 @@ func (in *RouteSpec) DeepCopyInto(out *RouteSpec) {
 		in, out := &in.AuthorizerID, &out.AuthorizerID
 		*out = new(string)
 		**out = **in
+	}
+	if in.AuthorizerRef != nil {
+		in, out := &in.AuthorizerRef, &out.AuthorizerRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ModelSelectionExpression != nil {
 		in, out := &in.ModelSelectionExpression, &out.ModelSelectionExpression
@@ -1894,6 +1924,11 @@ func (in *RouteSpec) DeepCopyInto(out *RouteSpec) {
 		in, out := &in.Target, &out.Target
 		*out = new(string)
 		**out = **in
+	}
+	if in.TargetRef != nil {
+		in, out := &in.TargetRef, &out.TargetRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -2126,6 +2161,11 @@ func (in *StageSpec) DeepCopyInto(out *StageSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.APIRef != nil {
+		in, out := &in.APIRef, &out.APIRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AutoDeploy != nil {
 		in, out := &in.AutoDeploy, &out.AutoDeploy
 		*out = new(bool)
@@ -2145,6 +2185,11 @@ func (in *StageSpec) DeepCopyInto(out *StageSpec) {
 		in, out := &in.DeploymentID, &out.DeploymentID
 		*out = new(string)
 		**out = **in
+	}
+	if in.DeploymentRef != nil {
+		in, out := &in.DeploymentRef, &out.DeploymentRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Description != nil {
 		in, out := &in.Description, &out.Description

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -39,6 +39,20 @@ spec:
             properties:
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               authorizerCredentialsARN:
                 type: string
               authorizerPayloadFormatVersion:
@@ -74,7 +88,6 @@ spec:
               name:
                 type: string
             required:
-            - apiID
             - authorizerType
             - identitySource
             - name

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -41,12 +41,24 @@ spec:
             properties:
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               description:
                 type: string
               stageName:
                 type: string
-            required:
-            - apiID
             type: object
           status:
             description: DeploymentStatus defines the observed state of Deployment

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -39,8 +39,36 @@ spec:
             properties:
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               connectionID:
                 type: string
+              connectionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               connectionType:
                 type: string
               contentHandlingStrategy:
@@ -90,7 +118,6 @@ spec:
                     type: string
                 type: object
             required:
-            - apiID
             - integrationType
             type: object
           status:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
@@ -41,6 +41,20 @@ spec:
                 type: string
               apiKeyRequired:
                 type: boolean
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               authorizationScopes:
                 items:
                   type: string
@@ -49,6 +63,20 @@ spec:
                 type: string
               authorizerID:
                 type: string
+              authorizerRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               modelSelectionExpression:
                 type: string
               operationName:
@@ -72,8 +100,21 @@ spec:
                 type: string
               target:
                 type: string
+              targetRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
             required:
-            - apiID
             - routeKey
             type: object
           status:

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
@@ -49,6 +49,20 @@ spec:
                 type: object
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               autoDeploy:
                 type: boolean
               clientCertificateID:
@@ -71,6 +85,20 @@ spec:
                 type: object
               deploymentID:
                 type: string
+              deploymentRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               description:
                 type: string
               routeSettings:
@@ -102,7 +130,6 @@ spec:
                   type: string
                 type: object
             required:
-            - apiID
             - stageName
             type: object
           status:

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,54 @@ resources:
     hooks:
       sdk_update_post_build_request:
         template_path: hooks/stage/sdk_update_post_build_request.go.tpl
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+      DeploymentId:
+        references:
+          resource: Deployment
+          path: Status.DeploymentID
+  Authorizer:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+  Deployment:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+  Integration:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+      ConnectionId:
+        references:
+          resource: VPCLink
+          path: Status.VPCLinkID
+  Route:
+    fields:
+      ApiId:
+        references:
+          resource: API
+          path: Status.APIID
+      AuthorizerId:
+        references:
+          resource: Authorizer
+          path: Status.AuthorizerID
+      Target:
+        references:
+          resource: Integration
+          path: Status.IntegrationID
+    hooks:
+      references_post_resolve:
+        template_path: hooks/route/references_post_resolve.go.tpl
   VpcLink:
     hooks:
       sdk_update_pre_build_request:

--- a/helm/crds/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -39,6 +39,20 @@ spec:
             properties:
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               authorizerCredentialsARN:
                 type: string
               authorizerPayloadFormatVersion:
@@ -74,7 +88,6 @@ spec:
               name:
                 type: string
             required:
-            - apiID
             - authorizerType
             - identitySource
             - name

--- a/helm/crds/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -41,12 +41,24 @@ spec:
             properties:
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               description:
                 type: string
               stageName:
                 type: string
-            required:
-            - apiID
             type: object
           status:
             description: DeploymentStatus defines the observed state of Deployment

--- a/helm/crds/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -39,8 +39,36 @@ spec:
             properties:
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               connectionID:
                 type: string
+              connectionRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               connectionType:
                 type: string
               contentHandlingStrategy:
@@ -90,7 +118,6 @@ spec:
                     type: string
                 type: object
             required:
-            - apiID
             - integrationType
             type: object
           status:

--- a/helm/crds/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_routes.yaml
@@ -41,6 +41,20 @@ spec:
                 type: string
               apiKeyRequired:
                 type: boolean
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               authorizationScopes:
                 items:
                   type: string
@@ -49,6 +63,20 @@ spec:
                 type: string
               authorizerID:
                 type: string
+              authorizerRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               modelSelectionExpression:
                 type: string
               operationName:
@@ -72,8 +100,21 @@ spec:
                 type: string
               target:
                 type: string
+              targetRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
             required:
-            - apiID
             - routeKey
             type: object
           status:

--- a/helm/crds/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_stages.yaml
@@ -49,6 +49,20 @@ spec:
                 type: object
               apiID:
                 type: string
+              apiRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               autoDeploy:
                 type: boolean
               clientCertificateID:
@@ -71,6 +85,20 @@ spec:
                 type: object
               deploymentID:
                 type: string
+              deploymentRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               description:
                 type: string
               routeSettings:
@@ -102,7 +130,6 @@ spec:
                   type: string
                 type: object
             required:
-            - apiID
             - stageName
             type: object
           status:

--- a/pkg/resource/authorizer/delta.go
+++ b/pkg/resource/authorizer/delta.go
@@ -48,6 +48,9 @@ func newResourceDelta(
 			delta.Add("Spec.APIID", a.ko.Spec.APIID, b.ko.Spec.APIID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.APIRef, b.ko.Spec.APIRef) {
+		delta.Add("Spec.APIRef", a.ko.Spec.APIRef, b.ko.Spec.APIRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.AuthorizerCredentialsARN, b.ko.Spec.AuthorizerCredentialsARN) {
 		delta.Add("Spec.AuthorizerCredentialsARN", a.ko.Spec.AuthorizerCredentialsARN, b.ko.Spec.AuthorizerCredentialsARN)
 	} else if a.ko.Spec.AuthorizerCredentialsARN != nil && b.ko.Spec.AuthorizerCredentialsARN != nil {

--- a/pkg/resource/authorizer/references.go
+++ b/pkg/resource/authorizer/references.go
@@ -17,8 +17,15 @@ package authorizer
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/apigatewayv2-controller/apis/v1alpha1"
@@ -36,17 +43,89 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForAPIID(ctx, apiReader, namespace, ko)
+	}
+
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Authorizer) error {
+	if ko.Spec.APIRef != nil && ko.Spec.APIID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("APIID", "APIRef")
+	}
+	if ko.Spec.APIRef == nil && ko.Spec.APIID == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("APIID", "APIRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Authorizer) bool {
-	return false
+	return false || ko.Spec.APIRef != nil
+}
+
+// resolveReferenceForAPIID reads the resource referenced
+// from APIRef field and sets the APIID
+// from referenced resource
+func resolveReferenceForAPIID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Authorizer,
+) error {
+	if ko.Spec.APIRef != nil &&
+		ko.Spec.APIRef.From != nil {
+		arr := ko.Spec.APIRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.API{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"API",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"API",
+				namespace, *arr.Name)
+		}
+		if obj.Status.APIID == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"API",
+				namespace, *arr.Name,
+				"Status.APIID")
+		}
+		ko.Spec.APIID = obj.Status.APIID
+	}
+	return nil
 }

--- a/pkg/resource/deployment/delta.go
+++ b/pkg/resource/deployment/delta.go
@@ -48,6 +48,9 @@ func newResourceDelta(
 			delta.Add("Spec.APIID", a.ko.Spec.APIID, b.ko.Spec.APIID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.APIRef, b.ko.Spec.APIRef) {
+		delta.Add("Spec.APIRef", a.ko.Spec.APIRef, b.ko.Spec.APIRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
 	} else if a.ko.Spec.Description != nil && b.ko.Spec.Description != nil {

--- a/pkg/resource/integration/delta.go
+++ b/pkg/resource/integration/delta.go
@@ -48,12 +48,18 @@ func newResourceDelta(
 			delta.Add("Spec.APIID", a.ko.Spec.APIID, b.ko.Spec.APIID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.APIRef, b.ko.Spec.APIRef) {
+		delta.Add("Spec.APIRef", a.ko.Spec.APIRef, b.ko.Spec.APIRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ConnectionID, b.ko.Spec.ConnectionID) {
 		delta.Add("Spec.ConnectionID", a.ko.Spec.ConnectionID, b.ko.Spec.ConnectionID)
 	} else if a.ko.Spec.ConnectionID != nil && b.ko.Spec.ConnectionID != nil {
 		if *a.ko.Spec.ConnectionID != *b.ko.Spec.ConnectionID {
 			delta.Add("Spec.ConnectionID", a.ko.Spec.ConnectionID, b.ko.Spec.ConnectionID)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.ConnectionRef, b.ko.Spec.ConnectionRef) {
+		delta.Add("Spec.ConnectionRef", a.ko.Spec.ConnectionRef, b.ko.Spec.ConnectionRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ConnectionType, b.ko.Spec.ConnectionType) {
 		delta.Add("Spec.ConnectionType", a.ko.Spec.ConnectionType, b.ko.Spec.ConnectionType)

--- a/pkg/resource/integration/references.go
+++ b/pkg/resource/integration/references.go
@@ -17,8 +17,15 @@ package integration
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/apigatewayv2-controller/apis/v1alpha1"
@@ -36,17 +43,151 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForAPIID(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForConnectionID(ctx, apiReader, namespace, ko)
+	}
+
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Integration) error {
+	if ko.Spec.APIRef != nil && ko.Spec.APIID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("APIID", "APIRef")
+	}
+	if ko.Spec.APIRef == nil && ko.Spec.APIID == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("APIID", "APIRef")
+	}
+	if ko.Spec.ConnectionRef != nil && ko.Spec.ConnectionID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ConnectionID", "ConnectionRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Integration) bool {
-	return false
+	return false || ko.Spec.ConnectionRef != nil || ko.Spec.APIRef != nil
+}
+
+// resolveReferenceForAPIID reads the resource referenced
+// from APIRef field and sets the APIID
+// from referenced resource
+func resolveReferenceForAPIID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Integration,
+) error {
+	if ko.Spec.APIRef != nil &&
+		ko.Spec.APIRef.From != nil {
+		arr := ko.Spec.APIRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.API{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"API",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"API",
+				namespace, *arr.Name)
+		}
+		if obj.Status.APIID == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"API",
+				namespace, *arr.Name,
+				"Status.APIID")
+		}
+		ko.Spec.APIID = obj.Status.APIID
+	}
+	return nil
+}
+
+// resolveReferenceForConnectionID reads the resource referenced
+// from ConnectionRef field and sets the ConnectionID
+// from referenced resource
+func resolveReferenceForConnectionID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Integration,
+) error {
+	if ko.Spec.ConnectionRef != nil &&
+		ko.Spec.ConnectionRef.From != nil {
+		arr := ko.Spec.ConnectionRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.VPCLink{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"VPCLink",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"VPCLink",
+				namespace, *arr.Name)
+		}
+		if obj.Status.VPCLinkID == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"VPCLink",
+				namespace, *arr.Name,
+				"Status.VPCLinkID")
+		}
+		ko.Spec.ConnectionID = obj.Status.VPCLinkID
+	}
+	return nil
 }

--- a/pkg/resource/route/delta.go
+++ b/pkg/resource/route/delta.go
@@ -55,6 +55,9 @@ func newResourceDelta(
 			delta.Add("Spec.APIKeyRequired", a.ko.Spec.APIKeyRequired, b.ko.Spec.APIKeyRequired)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.APIRef, b.ko.Spec.APIRef) {
+		delta.Add("Spec.APIRef", a.ko.Spec.APIRef, b.ko.Spec.APIRef)
+	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.AuthorizationScopes, b.ko.Spec.AuthorizationScopes) {
 		delta.Add("Spec.AuthorizationScopes", a.ko.Spec.AuthorizationScopes, b.ko.Spec.AuthorizationScopes)
 	}
@@ -71,6 +74,9 @@ func newResourceDelta(
 		if *a.ko.Spec.AuthorizerID != *b.ko.Spec.AuthorizerID {
 			delta.Add("Spec.AuthorizerID", a.ko.Spec.AuthorizerID, b.ko.Spec.AuthorizerID)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.AuthorizerRef, b.ko.Spec.AuthorizerRef) {
+		delta.Add("Spec.AuthorizerRef", a.ko.Spec.AuthorizerRef, b.ko.Spec.AuthorizerRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ModelSelectionExpression, b.ko.Spec.ModelSelectionExpression) {
 		delta.Add("Spec.ModelSelectionExpression", a.ko.Spec.ModelSelectionExpression, b.ko.Spec.ModelSelectionExpression)
@@ -120,6 +126,9 @@ func newResourceDelta(
 		if *a.ko.Spec.Target != *b.ko.Spec.Target {
 			delta.Add("Spec.Target", a.ko.Spec.Target, b.ko.Spec.Target)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.TargetRef, b.ko.Spec.TargetRef) {
+		delta.Add("Spec.TargetRef", a.ko.Spec.TargetRef, b.ko.Spec.TargetRef)
 	}
 
 	return delta

--- a/pkg/resource/stage/delta.go
+++ b/pkg/resource/stage/delta.go
@@ -66,6 +66,9 @@ func newResourceDelta(
 			delta.Add("Spec.APIID", a.ko.Spec.APIID, b.ko.Spec.APIID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.APIRef, b.ko.Spec.APIRef) {
+		delta.Add("Spec.APIRef", a.ko.Spec.APIRef, b.ko.Spec.APIRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.AutoDeploy, b.ko.Spec.AutoDeploy) {
 		delta.Add("Spec.AutoDeploy", a.ko.Spec.AutoDeploy, b.ko.Spec.AutoDeploy)
 	} else if a.ko.Spec.AutoDeploy != nil && b.ko.Spec.AutoDeploy != nil {
@@ -125,6 +128,9 @@ func newResourceDelta(
 		if *a.ko.Spec.DeploymentID != *b.ko.Spec.DeploymentID {
 			delta.Add("Spec.DeploymentID", a.ko.Spec.DeploymentID, b.ko.Spec.DeploymentID)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.DeploymentRef, b.ko.Spec.DeploymentRef) {
+		delta.Add("Spec.DeploymentRef", a.ko.Spec.DeploymentRef, b.ko.Spec.DeploymentRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/stage/references.go
+++ b/pkg/resource/stage/references.go
@@ -17,8 +17,15 @@ package stage
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/apigatewayv2-controller/apis/v1alpha1"
@@ -36,17 +43,151 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForAPIID(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForDeploymentID(ctx, apiReader, namespace, ko)
+	}
+
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Stage) error {
+	if ko.Spec.DeploymentRef != nil && ko.Spec.DeploymentID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DeploymentID", "DeploymentRef")
+	}
+	if ko.Spec.APIRef != nil && ko.Spec.APIID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("APIID", "APIRef")
+	}
+	if ko.Spec.APIRef == nil && ko.Spec.APIID == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("APIID", "APIRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Stage) bool {
-	return false
+	return false || ko.Spec.DeploymentRef != nil || ko.Spec.APIRef != nil
+}
+
+// resolveReferenceForAPIID reads the resource referenced
+// from APIRef field and sets the APIID
+// from referenced resource
+func resolveReferenceForAPIID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Stage,
+) error {
+	if ko.Spec.APIRef != nil &&
+		ko.Spec.APIRef.From != nil {
+		arr := ko.Spec.APIRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.API{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"API",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"API",
+				namespace, *arr.Name)
+		}
+		if obj.Status.APIID == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"API",
+				namespace, *arr.Name,
+				"Status.APIID")
+		}
+		ko.Spec.APIID = obj.Status.APIID
+	}
+	return nil
+}
+
+// resolveReferenceForDeploymentID reads the resource referenced
+// from DeploymentRef field and sets the DeploymentID
+// from referenced resource
+func resolveReferenceForDeploymentID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Stage,
+) error {
+	if ko.Spec.DeploymentRef != nil &&
+		ko.Spec.DeploymentRef.From != nil {
+		arr := ko.Spec.DeploymentRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.Deployment{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Deployment",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"Deployment",
+				namespace, *arr.Name)
+		}
+		if obj.Status.DeploymentID == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Deployment",
+				namespace, *arr.Name,
+				"Status.DeploymentID")
+		}
+		ko.Spec.DeploymentID = obj.Status.DeploymentID
+	}
+	return nil
 }

--- a/templates/hooks/route/references_post_resolve.go.tpl
+++ b/templates/hooks/route/references_post_resolve.go.tpl
@@ -1,0 +1,6 @@
+    // if the Target was provided using a reference, prepend "integrations/"
+    // with the IntegrationId from TargetRef
+    if ko.Spec.TargetRef != nil && ko.Spec.Target != nil {
+        targetStr := fmt.Sprintf("integrations/%s", *ko.Spec.Target)
+        ko.Spec.Target = &targetStr
+    }

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -35,5 +35,10 @@ REPLACEMENT_VALUES = {
     "VPC_LINK_RES_NAME": "ack-test",
     "VPC_LINK_NAME": "ack-test",
     "SUBNET_ID_1": "subnet-id-1",
-    "SUBNET_ID_2": "subnet-id-2"
+    "SUBNET_ID_2": "subnet-id-2",
+    "REF_API_NAME": "ack-test-ref-api",
+    "REF_INTEGRATION_NAME": "ack-test-ref-integration",
+    "REF_ROUTE_NAME": "ack-test-ref-route",
+    "REF_STAGE_NAME": "ack-test-ref-stage",
+    "REF_STAGE_DESCRIPTION": "Stage for ack resource reference testing"
 }

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -18,6 +18,8 @@ APIGatewayV2-specific test variables.
 REPLACEMENT_VALUES = {
     "API_NAME": "ack-test-api",
     "API_TITLE": "ack-test-api",
+    "IMPORT_API_NAME": "ack-test-import-api",
+    "IMPORT_API_TITLE": "ack-test-import-api",
     "API_ID": "api_id",
     "INTEGRATION_NAME": "ack-test-integration",
     "INTEGRATION_URI": "https://httpbin.org/get",

--- a/test/e2e/resources/httpapi-ref.yaml
+++ b/test/e2e/resources/httpapi-ref.yaml
@@ -1,0 +1,7 @@
+apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+kind: API
+metadata:
+  name: $REF_API_NAME
+spec:
+  name: $REF_API_NAME
+  protocolType: HTTP

--- a/test/e2e/resources/import_api.yaml
+++ b/test/e2e/resources/import_api.yaml
@@ -1,12 +1,12 @@
 apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
 kind: API
 metadata:
-  name: "$API_NAME"
+  name: "$IMPORT_API_NAME"
 spec:
   body: '{
             "openapi": "3.0.1",
             "info": {
-              "title": "$API_TITLE",
+              "title": "$IMPORT_API_TITLE",
               "version": "v1"
             },
             "paths": {

--- a/test/e2e/resources/integration-ref.yaml
+++ b/test/e2e/resources/integration-ref.yaml
@@ -1,0 +1,12 @@
+apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+kind: Integration
+metadata:
+  name: $REF_INTEGRATION_NAME
+spec:
+  apiRef:
+    from:
+      name: $REF_API_NAME
+  integrationType: HTTP_PROXY
+  integrationURI: https://httpbin.org/get
+  integrationMethod: GET
+  payloadFormatVersion: "1.0"

--- a/test/e2e/resources/route-ref.yaml
+++ b/test/e2e/resources/route-ref.yaml
@@ -1,0 +1,12 @@
+apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+kind: Route
+metadata:
+  name: $REF_ROUTE_NAME
+spec:
+  apiRef:
+    from:
+      name: $REF_API_NAME
+  routeKey: "GET /httpbin"
+  targetRef:
+    from:
+      name: $REF_INTEGRATION_NAME

--- a/test/e2e/resources/stage-ref.yaml
+++ b/test/e2e/resources/stage-ref.yaml
@@ -1,0 +1,11 @@
+apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+kind: Stage
+metadata:
+  name: $REF_STAGE_NAME
+spec:
+  apiRef:
+    from:
+      name: $REF_API_NAME
+  stageName: $REF_STAGE_NAME
+  autoDeploy: true
+  description: $REF_STAGE_DESCRIPTION

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -25,92 +25,92 @@ STAGE_RESOURCE_PLURAL = 'stages'
 VPC_LINK_RESOURCE_PLURAL = 'vpclinks'
 
 
-def api_ref_and_data(api_resource_name: str, replacement_values: dict):
+def api_ref_and_data(api_resource_name: str, replacement_values: dict, file_name: str = "httpapi"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, API_RESOURCE_PLURAL,
         api_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "httpapi",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data
 
 
-def import_api_ref_and_data(api_resource_name: str, replacement_values: dict):
+def import_api_ref_and_data(api_resource_name: str, replacement_values: dict, file_name: str = "import_api"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, API_RESOURCE_PLURAL,
         api_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "import_api",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data
 
 
-def integration_ref_and_data(integration_resource_name: str, replacement_values: dict):
+def integration_ref_and_data(integration_resource_name: str, replacement_values: dict, file_name: str = "integration"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, INTEGRATION_RESOURCE_PLURAL,
         integration_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "integration",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data
 
 
-def authorizer_ref_and_data(authorizer_resource_name: str, replacement_values: dict):
+def authorizer_ref_and_data(authorizer_resource_name: str, replacement_values: dict, file_name: str = "authorizer"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, AUTHORIZER_RESOURCE_PLURAL,
         authorizer_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "authorizer",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data
 
 
-def route_ref_and_data(route_resource_name: str, replacement_values: dict):
+def route_ref_and_data(route_resource_name: str, replacement_values: dict, file_name: str = "route"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, ROUTE_RESOURCE_PLURAL,
         route_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "route",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data
 
 
-def stage_ref_and_data(stage_resource_name: str, replacement_values: dict):
+def stage_ref_and_data(stage_resource_name: str, replacement_values: dict, file_name: str = "stage"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, STAGE_RESOURCE_PLURAL,
         stage_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "stage",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data
 
 
-def vpc_link_ref_and_data(vpc_link_resource_name: str, replacement_values: dict):
+def vpc_link_ref_and_data(vpc_link_resource_name: str, replacement_values: dict, file_name: str = "vpc-link"):
     ref = resource.CustomResourceReference(
         CRD_GROUP, CRD_VERSION, VPC_LINK_RESOURCE_PLURAL,
         vpc_link_resource_name, namespace="default",
     )
 
     resource_data = load_apigatewayv2_resource(
-        "vpc-link",
+        file_name,
         additional_replacements=replacement_values,
     )
     return ref, resource_data

--- a/test/e2e/tests/test_api.py
+++ b/test/e2e/tests/test_api.py
@@ -236,8 +236,8 @@ class TestApiGatewayV2:
     def test_crud_httpapi_using_import(self):
         test_data = REPLACEMENT_VALUES.copy()
         api_name = random_suffix_name("ack-test-importapi", 25)
-        test_data['API_NAME'] = api_name
-        test_data['API_TITLE'] = api_name
+        test_data['IMPORT_API_NAME'] = api_name
+        test_data['IMPORT_API_TITLE'] = api_name
         api_ref, api_data = helper.import_api_ref_and_data(api_resource_name=api_name,
                                                            replacement_values=test_data)
         logging.debug(f"imported http api resource. name: {api_name}, data: {api_data}")
@@ -261,7 +261,7 @@ class TestApiGatewayV2:
 
         # test update
         updated_api_title = 'updated-' + api_name
-        test_data['API_TITLE'] = updated_api_title
+        test_data['IMPORT_API_TITLE'] = updated_api_title
         updated_api_resource_data = load_apigatewayv2_resource(
             "import_api",
             additional_replacements=test_data,

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the API Gateway V2 resource references
+"""
+
+import logging
+import time
+
+import boto3
+import pytest
+
+from acktest.k8s import resource as k8s
+
+from e2e import service_marker, load_apigatewayv2_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+import e2e.tests.helper as helper
+from e2e.tests.helper import ApiGatewayValidator
+
+DELETE_WAIT_AFTER_SECONDS = 20
+
+apigw_validator = ApiGatewayValidator(boto3.client('apigatewayv2'))
+
+
+@service_marker
+@pytest.mark.canary
+class TestApiGatewayV2References:
+
+    def test_references(self):
+        test_data = REPLACEMENT_VALUES.copy()
+        api_name = test_data["REF_API_NAME"]
+        integration_name = test_data["REF_INTEGRATION_NAME"]
+        route_name = test_data["REF_ROUTE_NAME"]
+        stage_name = test_data["REF_STAGE_NAME"]
+
+        api_ref, api_data = helper.api_ref_and_data(api_resource_name=api_name,
+                                                    replacement_values=test_data,
+                                                    file_name="httpapi-ref")
+        logging.debug(f"api resource. name: {api_name}, data: {api_data}")
+
+        integration_ref, integration_data = helper.integration_ref_and_data(integration_resource_name=integration_name,
+                                                                            replacement_values=test_data,
+                                                                            file_name="integration-ref")
+        logging.debug(f"integration resource. name: {integration_name}, data: {integration_data}")
+
+        route_ref, route_data = helper.route_ref_and_data(route_resource_name=route_name,
+                                                          replacement_values=test_data,
+                                                          file_name="route-ref")
+        logging.debug(f"route resource. name: {route_name}, data: {route_data}")
+
+        stage_ref, stage_data = helper.stage_ref_and_data(stage_resource_name=stage_name,
+                                                          replacement_values=test_data,
+                                                          file_name="stage-ref")
+        logging.debug(f"stage resource. name: {stage_name}, data: {stage_data}")
+
+        # create the resources in order that initially the reference resolution fails and
+        # then when the referenced resource gets created, then all resolutions eventually
+        # pass and resources get synced.
+
+        # Create stage. Needs API reference
+        k8s.create_custom_resource(stage_ref, stage_data)
+        stage_cr = k8s.wait_resource_consumed_by_controller(stage_ref)
+        assert stage_cr is not None
+
+        # Create route. Needs API, Integration reference
+        k8s.create_custom_resource(route_ref, route_data)
+        route_cr = k8s.wait_resource_consumed_by_controller(route_ref)
+        assert route_cr is not None
+
+        # Create integration. Needs API reference
+        k8s.create_custom_resource(integration_ref, integration_data)
+        integration_cr = k8s.wait_resource_consumed_by_controller(integration_ref)
+        assert integration_cr is not None
+
+        # Create API. Needs no reference
+        k8s.create_custom_resource(api_ref, api_data)
+        api_cr = k8s.wait_resource_consumed_by_controller(api_ref)
+        assert api_cr is not None
+
+        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        assert k8s.wait_on_condition(integration_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
+        assert k8s.wait_on_condition(route_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
+        assert k8s.wait_on_condition(stage_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
+
+        api_cr = k8s.get_resource(api_ref)
+        api_id = api_cr['status']['apiID']
+
+        integration_cr = k8s.get_resource(integration_ref)
+        integration_id = integration_cr['status']['integrationID']
+
+        route_cr = k8s.get_resource(route_ref)
+        route_id = route_cr['status']['routeID']
+
+        # check that the resources in Amazon API Gateway
+        apigw_validator.assert_api_is_present(api_id=api_id)
+        apigw_validator.assert_integration_is_present(api_id=api_id, integration_id=integration_id)
+        apigw_validator.assert_route_is_present(api_id=api_id, route_id=route_id)
+        apigw_validator.assert_stage_is_present(api_id=api_id, stage_name=stage_name)
+
+        # DELETE
+        k8s.delete_custom_resource(stage_ref)
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        k8s.delete_custom_resource(route_ref)
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        k8s.delete_custom_resource(integration_ref)
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        k8s.delete_custom_resource(api_ref)
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        assert not k8s.get_resource_exists(stage_ref)
+        assert not k8s.get_resource_exists(route_ref)
+        assert not k8s.get_resource_exists(integration_ref)
+        assert not k8s.get_resource_exists(api_ref)
+
+        # check that the resources does not exist in Amazon API Gateway
+        apigw_validator.assert_stage_is_deleted(api_id=api_id, stage_name=stage_name)
+        apigw_validator.assert_route_is_deleted(api_id=api_id, route_id=route_id)
+        apigw_validator.assert_integration_is_deleted(api_id=api_id, integration_id=integration_id)
+        apigw_validator.assert_api_is_deleted(api_id=api_id)

--- a/test/e2e/tests/test_vpc_link.py
+++ b/test/e2e/tests/test_vpc_link.py
@@ -29,7 +29,7 @@ from e2e.replacement_values import REPLACEMENT_VALUES
 import e2e.tests.helper as helper
 from e2e.tests.helper import ApiGatewayValidator
 
-DELETE_WAIT_AFTER_SECONDS = 30
+DELETE_WAIT_AFTER_SECONDS = 60
 UPDATE_WAIT_AFTER_SECONDS = 10
 
 apigw_validator = ApiGatewayValidator(boto3.client('apigatewayv2'))


### PR DESCRIPTION
Description of changes:

* Add reference fields inside apigatewayv2 resources
* Add custom hook for resolving `TargetRef` inside Route resource because the integrationID needs to be prepended with "integrations/"
* Add e2e tests with manifest containing resource references

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
