### PR TITLE
remove permission from lambda function before deleting authorizer in e2e tests

### DIFF
--- a/test/e2e/tests/test_api.py
+++ b/test/e2e/tests/test_api.py
@@ -114,14 +114,17 @@ def authorizer_resource(api_resource):
         authorizer_id=authorizer_id
     )
     lambda_client = boto3.client("lambda")
-    lambda_client.add_permission(FunctionName=get_bootstrap_resources().AuthorizerFunctionName,
-                                 StatementId=random_suffix_name('invoke-permission', 25),
+    function_name = get_bootstrap_resources().AuthorizerFunctionName
+    statement_id = random_suffix_name('invoke-permission', 25)
+    lambda_client.add_permission(FunctionName=function_name,
+                                 StatementId=statement_id,
                                  Action='lambda:InvokeFunction',
                                  Principal='apigateway.amazonaws.com',
                                  SourceArn=authorizer_arn)
 
     yield authorizer_ref, cr
 
+    lambda_client.remove_permission(FunctionName=function_name, StatementId=statement_id)
     k8s.delete_custom_resource(authorizer_ref)
 
 


### PR DESCRIPTION
Description of changes:

* remove permission from lambda function before deleting authorizer in e2e tests
* This issue was surfaced when soak tests ran for more than 3 hours and limit of resource policy per lambda was hit. This caused skewed results in soak tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
