### PR TITLE
Set authorizer lambda runtime to node18.x

### DIFF
--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -72,7 +72,7 @@ def create_lambda_authorizer(authorizer_function_name: str, authorizer_role_arn:
             FunctionName=authorizer_function_name,
             Role=authorizer_role_arn,
             Handler='index.handler',
-            Runtime='nodejs12.x',
+            Runtime='nodejs18.x',
             Code={'ZipFile': b64_encoded_zip_file}
         )
 


### PR DESCRIPTION
Fixes: https://github.com/aws-controllers-k8s/community/issues/1825

Set authorizer lambda runtime to node18.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
