### PR TITLE
tests: Ready condition rename for apigatewayv2-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.51.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.35.0 h1:jTPxEJyzjSuuz0wB+302hr8Eu9KUI+Zv8zlujMGJpVI=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.51.0 h1:dgf25lfg5r1kjJtHzdbNrMtQVloYn77WLYi1X41NXhw=
+github.com/gustavodiaz7722/ack-runtime v0.51.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@38ce32256cc2552ab54e190cc8a8618e93af9e0c
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@075991b980ffbc9177f0427270be707359240f89

--- a/test/e2e/tests/test_api.py
+++ b/test/e2e/tests/test_api.py
@@ -54,7 +54,7 @@ def api_resource():
 
     k8s.create_custom_resource(api_ref, api_data)
     time.sleep(CREATE_API_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(api_ref)
     assert cr is not None
@@ -80,7 +80,7 @@ def integration_resource(api_resource):
 
     k8s.create_custom_resource(integration_ref, integration_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(integration_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(integration_ref)
     assert cr is not None
@@ -103,7 +103,7 @@ def authorizer_resource(api_resource):
                                                                      replacement_values=test_resource_values)
     k8s.create_custom_resource(authorizer_ref, authorizer_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(authorizer_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(authorizer_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(authorizer_ref)
     assert cr is not None
@@ -142,7 +142,7 @@ def route_resource(integration_resource, authorizer_resource):
 
     k8s.create_custom_resource(route_ref, route_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(route_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(route_ref)
     assert cr is not None
@@ -165,7 +165,7 @@ def stage_resource(route_resource):
 
     k8s.create_custom_resource(stage_ref, stage_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(stage_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(stage_ref)
     assert cr is not None
@@ -202,7 +202,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(api_ref, api_data)
         time.sleep(CREATE_API_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(api_ref)
         assert cr is not None
@@ -230,7 +230,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(api_ref, updated_api_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(api_ref)
+        condition.assert_ready(api_ref)
         # Let's check that the HTTP Api appears in Amazon API Gateway with updated title
         apigw_validator.assert_api_name(
             api_id=api_id,
@@ -256,7 +256,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(api_ref, api_data)
         time.sleep(CREATE_API_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(api_ref)
         assert cr is not None
@@ -284,7 +284,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(api_ref, updated_api_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(api_ref)
+        condition.assert_ready(api_ref)
         # Let's check that the HTTP Api appears in Amazon API Gateway with updated title
         apigw_validator.assert_api_name(
             api_id=api_id,
@@ -312,7 +312,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(integration_ref, integration_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(integration_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(integration_ref)
         assert cr is not None
@@ -341,7 +341,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(integration_ref, updated_integration_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(integration_ref)
+        condition.assert_ready(integration_ref)
         # Let's check that the HTTP Api integration appears in Amazon API Gateway with updated uri
         apigw_validator.assert_integration_uri(
             api_id=api_id,
@@ -372,7 +372,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(authorizer_ref, authorizer_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(authorizer_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(authorizer_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(authorizer_ref)
         assert cr is not None
@@ -401,7 +401,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(authorizer_ref, updated_authorizer_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(authorizer_ref)
+        condition.assert_ready(authorizer_ref)
         # Let's check that the HTTP Api authorizer appears in Amazon API Gateway with updated title
         apigw_validator.assert_authorizer_name(
             api_id=api_id,
@@ -437,7 +437,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(route_ref, route_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(route_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(route_ref)
         assert cr is not None
@@ -466,7 +466,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(route_ref, updated_route_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(route_ref)
+        condition.assert_ready(route_ref)
         # Let's check that the HTTP Api route appears in Amazon API Gateway with updated route key
         apigw_validator.assert_route_key(
             api_id=api_id,
@@ -495,7 +495,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(stage_ref, stage_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(stage_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(stage_ref)
         assert cr is not None
@@ -523,7 +523,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(stage_ref, updated_stage_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(stage_ref)
+        condition.assert_ready(stage_ref)
         # Let's check that the HTTP Api stage appears in Amazon API Gateway with updated description
         apigw_validator.assert_stage_description(
             api_id=api_id,

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -82,10 +82,10 @@ class TestApiGatewayV2References:
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
-        assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
-        assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
-        assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
+        assert k8s.wait_on_condition(integration_ref, "Ready", "True", wait_periods=10)
+        assert k8s.wait_on_condition(route_ref, "Ready", "True", wait_periods=10)
+        assert k8s.wait_on_condition(stage_ref, "Ready", "True", wait_periods=10)
 
         assert k8s.wait_on_condition(integration_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
         assert k8s.wait_on_condition(route_ref, "ACK.ReferencesResolved", "True", wait_periods=10)

--- a/test/e2e/tests/test_vpc_link.py
+++ b/test/e2e/tests/test_vpc_link.py
@@ -57,7 +57,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(vpc_link_ref, vpc_link_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(vpc_link_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_link_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(vpc_link_ref)
         assert cr is not None
@@ -85,7 +85,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(vpc_link_ref, updated_vpc_link_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(vpc_link_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_link_ref, "Ready", "True", wait_periods=10)
         # Let's check that the VPCLink appears in Amazon API Gateway with updated name
         apigw_validator.assert_vpc_link_name(
             vpc_link_id=vpc_link_id,


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.