### PR TITLE
tests: Ready condition rename for apigatewayv2-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T17:03:57Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:10:20Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: 5111539ac4c4401f7da6826a1911e116e83f57a4
 api_version: v1alpha1
 aws_sdk_go_version: 1.32.6

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_apimappings.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_apimappings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: apimappings.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: apis.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: authorizers.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: deployments.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_domainnames.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_domainnames.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: domainnames.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: integrations.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: routes.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: stages.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/config/crd/bases/apigatewayv2.services.k8s.aws_vpclinks.yaml
+++ b/config/crd/bases/apigatewayv2.services.k8s.aws_vpclinks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpclinks.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.35.0 h1:jTPxEJyzjSuuz0wB+302hr8Eu9KUI+Zv8zlujMGJpVI=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/apigatewayv2.services.k8s.aws_apimappings.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_apimappings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: apimappings.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_apis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: apis.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: authorizers.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: deployments.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_domainnames.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_domainnames.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: domainnames.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: integrations.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_routes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: routes.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_stages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: stages.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/apigatewayv2.services.k8s.aws_vpclinks.yaml
+++ b/helm/crds/apigatewayv2.services.k8s.aws_vpclinks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpclinks.apigatewayv2.services.k8s.aws
 spec:
   group: apigatewayv2.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/api_mapping/references.go
+++ b/pkg/resource/api_mapping/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -149,8 +150,9 @@ func getReferencedResourceState_API(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"API",
 				namespace, name)
@@ -161,14 +163,14 @@ func getReferencedResourceState_API(
 			"API",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"API",
 			namespace, name)
@@ -232,8 +234,9 @@ func getReferencedResourceState_DomainName(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"DomainName",
 				namespace, name)
@@ -244,14 +247,14 @@ func getReferencedResourceState_DomainName(
 			"DomainName",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"DomainName",
 			namespace, name)

--- a/pkg/resource/authorizer/references.go
+++ b/pkg/resource/authorizer/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -132,8 +133,9 @@ func getReferencedResourceState_API(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"API",
 				namespace, name)
@@ -144,14 +146,14 @@ func getReferencedResourceState_API(
 			"API",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"API",
 			namespace, name)

--- a/pkg/resource/deployment/references.go
+++ b/pkg/resource/deployment/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -132,8 +133,9 @@ func getReferencedResourceState_API(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"API",
 				namespace, name)
@@ -144,14 +146,14 @@ func getReferencedResourceState_API(
 			"API",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"API",
 			namespace, name)

--- a/pkg/resource/integration/references.go
+++ b/pkg/resource/integration/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -146,8 +147,9 @@ func getReferencedResourceState_API(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"API",
 				namespace, name)
@@ -158,14 +160,14 @@ func getReferencedResourceState_API(
 			"API",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"API",
 			namespace, name)
@@ -229,8 +231,9 @@ func getReferencedResourceState_VPCLink(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPCLink",
 				namespace, name)
@@ -241,14 +244,14 @@ func getReferencedResourceState_VPCLink(
 			"VPCLink",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPCLink",
 			namespace, name)

--- a/pkg/resource/route/references.go
+++ b/pkg/resource/route/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -167,8 +168,9 @@ func getReferencedResourceState_API(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"API",
 				namespace, name)
@@ -179,14 +181,14 @@ func getReferencedResourceState_API(
 			"API",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"API",
 			namespace, name)
@@ -250,8 +252,9 @@ func getReferencedResourceState_Authorizer(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Authorizer",
 				namespace, name)
@@ -262,14 +265,14 @@ func getReferencedResourceState_Authorizer(
 			"Authorizer",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Authorizer",
 			namespace, name)
@@ -333,8 +336,9 @@ func getReferencedResourceState_Integration(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Integration",
 				namespace, name)
@@ -345,14 +349,14 @@ func getReferencedResourceState_Integration(
 			"Integration",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Integration",
 			namespace, name)

--- a/pkg/resource/stage/references.go
+++ b/pkg/resource/stage/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -146,8 +147,9 @@ func getReferencedResourceState_API(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"API",
 				namespace, name)
@@ -158,14 +160,14 @@ func getReferencedResourceState_API(
 			"API",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"API",
 			namespace, name)
@@ -229,8 +231,9 @@ func getReferencedResourceState_Deployment(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Deployment",
 				namespace, name)
@@ -241,14 +244,14 @@ func getReferencedResourceState_Deployment(
 			"Deployment",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Deployment",
 			namespace, name)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@38ce32256cc2552ab54e190cc8a8618e93af9e0c
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428

--- a/test/e2e/tests/test_api.py
+++ b/test/e2e/tests/test_api.py
@@ -54,7 +54,7 @@ def api_resource():
 
     k8s.create_custom_resource(api_ref, api_data)
     time.sleep(CREATE_API_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(api_ref)
     assert cr is not None
@@ -80,7 +80,7 @@ def integration_resource(api_resource):
 
     k8s.create_custom_resource(integration_ref, integration_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(integration_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(integration_ref)
     assert cr is not None
@@ -103,7 +103,7 @@ def authorizer_resource(api_resource):
                                                                      replacement_values=test_resource_values)
     k8s.create_custom_resource(authorizer_ref, authorizer_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(authorizer_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(authorizer_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(authorizer_ref)
     assert cr is not None
@@ -142,7 +142,7 @@ def route_resource(integration_resource, authorizer_resource):
 
     k8s.create_custom_resource(route_ref, route_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(route_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(route_ref)
     assert cr is not None
@@ -165,7 +165,7 @@ def stage_resource(route_resource):
 
     k8s.create_custom_resource(stage_ref, stage_data)
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
-    assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(stage_ref, "Ready", "True", wait_periods=10)
 
     cr = k8s.get_resource(stage_ref)
     assert cr is not None
@@ -202,7 +202,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(api_ref, api_data)
         time.sleep(CREATE_API_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(api_ref)
         assert cr is not None
@@ -230,7 +230,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(api_ref, updated_api_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(api_ref)
+        condition.assert_ready(api_ref)
         # Let's check that the HTTP Api appears in Amazon API Gateway with updated title
         apigw_validator.assert_api_name(
             api_id=api_id,
@@ -256,7 +256,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(api_ref, api_data)
         time.sleep(CREATE_API_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(api_ref)
         assert cr is not None
@@ -284,7 +284,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(api_ref, updated_api_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(api_ref)
+        condition.assert_ready(api_ref)
         # Let's check that the HTTP Api appears in Amazon API Gateway with updated title
         apigw_validator.assert_api_name(
             api_id=api_id,
@@ -312,7 +312,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(integration_ref, integration_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(integration_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(integration_ref)
         assert cr is not None
@@ -341,7 +341,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(integration_ref, updated_integration_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(integration_ref)
+        condition.assert_ready(integration_ref)
         # Let's check that the HTTP Api integration appears in Amazon API Gateway with updated uri
         apigw_validator.assert_integration_uri(
             api_id=api_id,
@@ -372,7 +372,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(authorizer_ref, authorizer_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(authorizer_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(authorizer_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(authorizer_ref)
         assert cr is not None
@@ -401,7 +401,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(authorizer_ref, updated_authorizer_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(authorizer_ref)
+        condition.assert_ready(authorizer_ref)
         # Let's check that the HTTP Api authorizer appears in Amazon API Gateway with updated title
         apigw_validator.assert_authorizer_name(
             api_id=api_id,
@@ -437,7 +437,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(route_ref, route_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(route_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(route_ref)
         assert cr is not None
@@ -466,7 +466,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(route_ref, updated_route_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(route_ref)
+        condition.assert_ready(route_ref)
         # Let's check that the HTTP Api route appears in Amazon API Gateway with updated route key
         apigw_validator.assert_route_key(
             api_id=api_id,
@@ -495,7 +495,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(stage_ref, stage_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(stage_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(stage_ref)
         assert cr is not None
@@ -523,7 +523,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(stage_ref, updated_stage_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        condition.assert_synced(stage_ref)
+        condition.assert_ready(stage_ref)
         # Let's check that the HTTP Api stage appears in Amazon API Gateway with updated description
         apigw_validator.assert_stage_description(
             api_id=api_id,

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -82,10 +82,10 @@ class TestApiGatewayV2References:
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(api_ref, "ACK.ResourceSynced", "True", wait_periods=10)
-        assert k8s.wait_on_condition(integration_ref, "ACK.ResourceSynced", "True", wait_periods=10)
-        assert k8s.wait_on_condition(route_ref, "ACK.ResourceSynced", "True", wait_periods=10)
-        assert k8s.wait_on_condition(stage_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(api_ref, "Ready", "True", wait_periods=10)
+        assert k8s.wait_on_condition(integration_ref, "Ready", "True", wait_periods=10)
+        assert k8s.wait_on_condition(route_ref, "Ready", "True", wait_periods=10)
+        assert k8s.wait_on_condition(stage_ref, "Ready", "True", wait_periods=10)
 
         assert k8s.wait_on_condition(integration_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
         assert k8s.wait_on_condition(route_ref, "ACK.ReferencesResolved", "True", wait_periods=10)

--- a/test/e2e/tests/test_vpc_link.py
+++ b/test/e2e/tests/test_vpc_link.py
@@ -57,7 +57,7 @@ class TestApiGatewayV2:
         # test create
         k8s.create_custom_resource(vpc_link_ref, vpc_link_data)
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(vpc_link_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_link_ref, "Ready", "True", wait_periods=10)
 
         cr = k8s.get_resource(vpc_link_ref)
         assert cr is not None
@@ -85,7 +85,7 @@ class TestApiGatewayV2:
         k8s.patch_custom_resource(vpc_link_ref, updated_vpc_link_resource_data)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
 
-        assert k8s.wait_on_condition(vpc_link_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_link_ref, "Ready", "True", wait_periods=10)
         # Let's check that the VPCLink appears in Amazon API Gateway with updated name
         apigw_validator.assert_vpc_link_name(
             vpc_link_id=vpc_link_id,


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._