### PR TITLE
Mark API.Body as is_document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:40:20Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
+  build_date: "2026-06-19T04:03:25Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
+  go_version: go1.26.0
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: 5111539ac4c4401f7da6826a1911e116e83f57a4
 api_version: v1alpha1
 aws_sdk_go_version: 1.32.6
 generator_config_info:
-  file_checksum: 6151f468bc35004a1306f250ef465e62c9ee8949
+  file_checksum: 50c786cc9732281c1df4782dad8f3bc9c3168b0b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -18,6 +18,7 @@ resources:
   Api:
     fields:
       Body:
+        is_document: true
         from:
           operation: ImportApi
           path: Body

--- a/generator.yaml
+++ b/generator.yaml
@@ -18,6 +18,7 @@ resources:
   Api:
     fields:
       Body:
+        is_document: true
         from:
           operation: ImportApi
           path: Body

--- a/pkg/resource/api/delta.go
+++ b/pkg/resource/api/delta.go
@@ -58,7 +58,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Body, b.ko.Spec.Body) {
 		delta.Add("Spec.Body", a.ko.Spec.Body, b.ko.Spec.Body)
 	} else if a.ko.Spec.Body != nil && b.ko.Spec.Body != nil {
-		if *a.ko.Spec.Body != *b.ko.Spec.Body {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.Body, *b.ko.Spec.Body); err != nil || !equal {
 			delta.Add("Spec.Body", a.ko.Spec.Body, b.ko.Spec.Body)
 		}
 	}


### PR DESCRIPTION
## Summary

Adds is_document: true annotation to Api.Body field in generator.yaml.

## Problem

The API.Body field accepts an OpenAPI definition document (JSON/YAML). Without the is_document annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added is_document: true to Api.Body in generator.yaml
- Regenerated controller code - delta.go now uses DocumentEqual for semantic comparison

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e test (import_api.yaml fixture) already exercises the body field with JSON content

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.